### PR TITLE
fix scalar subquery expression parentheses

### DIFF
--- a/internal/formatter.go
+++ b/internal/formatter.go
@@ -541,7 +541,6 @@ func (n *SubqueryExprNode) FormatSQL(ctx context.Context) (string, error) {
 	}
 	switch n.node.SubqueryType() {
 	case ast.SubqueryTypeScalar:
-		return fmt.Sprintf("(%s)", sql), nil
 	case ast.SubqueryTypeArray:
 		if len(n.node.Subquery().ColumnList()) == 0 {
 			return "", fmt.Errorf("failed to find computed column names for array subquery")
@@ -559,7 +558,7 @@ func (n *SubqueryExprNode) FormatSQL(ctx context.Context) (string, error) {
 	case ast.SubqueryTypeLikeAny:
 	case ast.SubqueryTypeLikeAll:
 	}
-	return sql, nil
+	return fmt.Sprintf("(%s)", sql), nil
 }
 
 func (n *LetExprNode) FormatSQL(ctx context.Context) (string, error) {

--- a/internal/formatter.go
+++ b/internal/formatter.go
@@ -541,6 +541,7 @@ func (n *SubqueryExprNode) FormatSQL(ctx context.Context) (string, error) {
 	}
 	switch n.node.SubqueryType() {
 	case ast.SubqueryTypeScalar:
+		return fmt.Sprintf("(%s)", sql), nil
 	case ast.SubqueryTypeArray:
 		if len(n.node.Subquery().ColumnList()) == 0 {
 			return "", fmt.Errorf("failed to find computed column names for array subquery")

--- a/query_test.go
+++ b/query_test.go
@@ -3223,37 +3223,37 @@ FROM
 
 		// subquery expr
 		{
-			name:         "SubqueryExpr(subquery_type=SCALAR) at SELECT",
+			name:         "subquery expr with scalar type at SELECT",
 			query:        "SELECT (SELECT 1)",
 			expectedRows: [][]interface{}{{int64(1)}},
 		},
 		{
-			name:         "SubqueryExpr(subquery_type=SCALAR) at WHERE",
+			name:         "subquery expr with scalar type at WHERE",
 			query:        "SELECT * FROM UNNEST([1, 2, 3]) AS val WHERE val = (SELECT 1)",
 			expectedRows: [][]interface{}{{int64(1)}},
 		},
 		{
-			name:         "SubqueryExpr(subquery_type=SCALAR) at HAVING",
+			name:         "subquery expr with scalar type at HAVING",
 			query:        "SELECT * FROM UNNEST([1, 2, 3]) AS val GROUP BY val HAVING val = (SELECT 1)",
 			expectedRows: [][]interface{}{{int64(1)}},
 		},
 		{
-			name:         "SubqueryExpr(subquery_type=SCALAR) at FunctionCall",
+			name:         "subquery expr with scalar type at function call",
 			query:        "SELECT ABS((SELECT 1))",
 			expectedRows: [][]interface{}{{int64(1)}},
 		},
 		{
-			name:         "SubqueryExpr(subquery_type=ARRAY)",
+			name:         "subquery expr with array type",
 			query:        "SELECT ARRAY(SELECT * FROM UNNEST([1, 2, 3]))",
 			expectedRows: [][]interface{}{{[]interface{}{int64(1), int64(2), int64(3)}}},
 		},
 		{
-			name:         "SubqueryExpr(subquery_type=IN)",
+			name:         "subquery expr with in type",
 			query:        "SELECT * FROM UNNEST([1, 2, 3]) AS val WHERE val IN (SELECT 1)",
 			expectedRows: [][]interface{}{{int64(1)}},
 		},
 		{
-			name:         "SubqueryExpr(subquery_type=EXISTS)",
+			name:         "subquery expr with exists type",
 			query:        `SELECT EXISTS ( SELECT val FROM UNNEST([1, 2, 3]) AS val WHERE val = 1 )`,
 			expectedRows: [][]interface{}{{true}},
 		},

--- a/query_test.go
+++ b/query_test.go
@@ -3220,6 +3220,28 @@ FROM
 				{"false", "boolean"},
 			},
 		},
+
+		// subquery expr
+		{
+			name:         "subquery_expr_type_scalar",
+			query:        "SELECT (SELECT 1)",
+			expectedRows: [][]interface{}{{int64(1)}},
+		},
+		{
+			name:         "subquery_expr_type_array",
+			query:        "SELECT ARRAY(SELECT * FROM UNNEST([1, 2, 3]))",
+			expectedRows: [][]interface{}{{[]interface{}{int64(1), int64(2), int64(3)}}},
+		},
+		{
+			name:         "subquery_expr_type_in",
+			query:        "SELECT * FROM UNNEST([1, 2, 3]) AS val WHERE val IN (SELECT 1)",
+			expectedRows: [][]interface{}{{int64(1)}},
+		},
+		{
+			name:         "subquery_expr_type_exists",
+			query:        `SELECT EXISTS ( SELECT val FROM UNNEST([1, 2, 3]) AS val WHERE val = 1 )`,
+			expectedRows: [][]interface{}{{true}},
+		},
 	} {
 		test := test
 		t.Run(test.name, func(t *testing.T) {

--- a/query_test.go
+++ b/query_test.go
@@ -3223,22 +3223,37 @@ FROM
 
 		// subquery expr
 		{
-			name:         "subquery_expr_type_scalar",
+			name:         "SubqueryExpr(subquery_type=SCALAR) at SELECT",
 			query:        "SELECT (SELECT 1)",
 			expectedRows: [][]interface{}{{int64(1)}},
 		},
 		{
-			name:         "subquery_expr_type_array",
+			name:         "SubqueryExpr(subquery_type=SCALAR) at WHERE",
+			query:        "SELECT * FROM UNNEST([1, 2, 3]) AS val WHERE val = (SELECT 1)",
+			expectedRows: [][]interface{}{{int64(1)}},
+		},
+		{
+			name:         "SubqueryExpr(subquery_type=SCALAR) at HAVING",
+			query:        "SELECT * FROM UNNEST([1, 2, 3]) AS val GROUP BY val HAVING val = (SELECT 1)",
+			expectedRows: [][]interface{}{{int64(1)}},
+		},
+		{
+			name:         "SubqueryExpr(subquery_type=SCALAR) at FunctionCall",
+			query:        "SELECT ABS((SELECT 1))",
+			expectedRows: [][]interface{}{{int64(1)}},
+		},
+		{
+			name:         "SubqueryExpr(subquery_type=ARRAY)",
 			query:        "SELECT ARRAY(SELECT * FROM UNNEST([1, 2, 3]))",
 			expectedRows: [][]interface{}{{[]interface{}{int64(1), int64(2), int64(3)}}},
 		},
 		{
-			name:         "subquery_expr_type_in",
+			name:         "SubqueryExpr(subquery_type=IN)",
 			query:        "SELECT * FROM UNNEST([1, 2, 3]) AS val WHERE val IN (SELECT 1)",
 			expectedRows: [][]interface{}{{int64(1)}},
 		},
 		{
-			name:         "subquery_expr_type_exists",
+			name:         "SubqueryExpr(subquery_type=EXISTS)",
 			query:        `SELECT EXISTS ( SELECT val FROM UNNEST([1, 2, 3]) AS val WHERE val = 1 )`,
 			expectedRows: [][]interface{}{{true}},
 		},


### PR DESCRIPTION
fix #34 

Hi. I've found that some kinds of subquery expressions cause errors, so I've tried to fix it.

It seems that `SubqueryExpr(subquery_type=SCALAR)` must be enclosed in parentheses. (I'm fairly new to ZetaSQL and go-zetasqlite so not 100% sure though)

----

:red_square: red status before fix with added tests

```
$ CXX=clang++ go test -run TestQuery/subquery_expr -v
=== RUN   TestQuery
=== RUN   TestQuery/subquery_expr_type_scalar
    query_test.go:3251: failed to query SELECT SELECT 1 AS `$col1#1`  AS `$col1#2` : near "SELECT": syntax error
=== RUN   TestQuery/subquery_expr_type_array
=== RUN   TestQuery/subquery_expr_type_in
=== RUN   TestQuery/subquery_expr_type_exists
--- FAIL: TestQuery (0.01s)
    --- FAIL: TestQuery/subquery_expr_type_scalar (0.00s)
    --- PASS: TestQuery/subquery_expr_type_array (0.00s)
    --- PASS: TestQuery/subquery_expr_type_in (0.00s)
    --- PASS: TestQuery/subquery_expr_type_exists (0.00s)
FAIL
exit status 1
FAIL	github.com/goccy/go-zetasqlite	0.026s
```