### PR TITLE
Fix catalog

### DIFF
--- a/internal/analyzer.go
+++ b/internal/analyzer.go
@@ -219,7 +219,7 @@ func (it *AnalyzerOutputIterator) Next() bool {
 	out, err := zetasql.AnalyzeStatementFromParserAST(
 		it.query,
 		stmt.stmt,
-		it.analyzer.catalog.getCatalog(it.analyzer.namePath),
+		it.analyzer.catalog.catalog,
 		it.analyzer.opt,
 	)
 	it.err = err


### PR DESCRIPTION
ref https://github.com/goccy/bigquery-emulator/issues/70

In order to support multiple datasets, we had to use different catalogs for each dataset. However, using different catalogs caused a problem that the catalogs that should be referenced could not be referenced. Therefore, we will modify the bigquery-emulator for using a common catalog, so that the projectID / datasetID is assigned before the query is executed.