### PR TITLE
Set `SQLITE_LIMIT_VARIABLE_NUMBER`

### DIFF
--- a/driver.go
+++ b/driver.go
@@ -30,6 +30,7 @@ func init() {
 			if err := internal.RegisterFunctions(conn); err != nil {
 				return err
 			}
+			conn.SetLimit(sqlite3.SQLITE_LIMIT_VARIABLE_NUMBER, -1)
 			return nil
 		},
 	})


### PR DESCRIPTION
## Background
In my environment I sometimes want to perform an Insert of several thousand records.
In doing so, I get `too many SQL variables error`.
So I want to avoid this error by setting SQLITE_LIMIT_VARIABLE_NUMBER.
ref: https://www.sqlite.org/limits.html#max_variable_number