### PR TITLE
Fix with clause in subquery

### DIFF
--- a/internal/analyzer.go
+++ b/internal/analyzer.go
@@ -216,6 +216,7 @@ func (a *Analyzer) context(
 	ctx = withFuncMap(ctx, funcMap)
 	ctx = withAnalyticOrderColumnNames(ctx, &analyticOrderColumnNames{})
 	ctx = withNodeMap(ctx, zetasql.NewNodeMap(stmtNode, stmt))
+	ctx = withWithEntries(ctx, &withSubqueryEntries{})
 	return ctx
 }
 

--- a/internal/context.go
+++ b/internal/context.go
@@ -25,6 +25,8 @@ type (
 	useColumnIDKey                  struct{}
 	rowIDColumnKey                  struct{}
 	useTableNameForColumnKey        struct{}
+	withEntriesKey                  struct{}
+	withSubqueryKey                 struct{}
 )
 
 func analyzerFromContext(ctx context.Context) *Analyzer {
@@ -222,6 +224,34 @@ func withRowIDColumn(ctx context.Context) context.Context {
 
 func needsRowIDColumn(ctx context.Context) bool {
 	value := ctx.Value(rowIDColumnKey{})
+	if value == nil {
+		return false
+	}
+	return value.(bool)
+}
+
+type withSubqueryEntries struct {
+	entries []string
+}
+
+func withWithEntries(ctx context.Context, entries *withSubqueryEntries) context.Context {
+	return context.WithValue(ctx, withEntriesKey{}, entries)
+}
+
+func withEntries(ctx context.Context) *withSubqueryEntries {
+	value := ctx.Value(withEntriesKey{})
+	if value == nil {
+		return nil
+	}
+	return value.(*withSubqueryEntries)
+}
+
+func withWithSubquery(ctx context.Context) context.Context {
+	return context.WithValue(ctx, withSubqueryKey{}, true)
+}
+
+func withSubquery(ctx context.Context) bool {
+	value := ctx.Value(withSubqueryKey{})
 	if value == nil {
 		return false
 	}

--- a/internal/formatter.go
+++ b/internal/formatter.go
@@ -1470,6 +1470,15 @@ func (n *WithScanNode) FormatSQL(ctx context.Context) (string, error) {
 	if err != nil {
 		return "", err
 	}
+	if withSubquery(ctx) {
+		e := withEntries(ctx)
+		e.entries = append(e.entries, queries...)
+		return query, nil
+	}
+	e := withEntries(ctx)
+	if len(e.entries) != 0 {
+		queries = append(e.entries, queries...)
+	}
 	return fmt.Sprintf(
 		"WITH %s %s",
 		strings.Join(queries, ", "),
@@ -1482,7 +1491,7 @@ func (n *WithEntryNode) FormatSQL(ctx context.Context) (string, error) {
 		return "", nil
 	}
 	queryName := n.node.WithQueryName()
-	subquery, err := newNode(n.node.WithSubquery()).FormatSQL(ctx)
+	subquery, err := newNode(n.node.WithSubquery()).FormatSQL(withWithSubquery(ctx))
 	if err != nil {
 		return "", err
 	}

--- a/query_test.go
+++ b/query_test.go
@@ -4555,11 +4555,35 @@ FROM
 			query:        `SELECT EXISTS ( SELECT val FROM UNNEST([1, 2, 3]) AS val WHERE val = 1 )`,
 			expectedRows: [][]interface{}{{true}},
 		},
-
+		{
+			name: "subquery with",
+			query: `
+WITH tmp as (
+  SELECT * FROM (
+    WITH A AS (
+      SELECT * FROM (SELECT 1 AS id)
+    )  SELECT * FROM A
+  )
+) SELECT id FROM tmp`,
+			expectedRows: [][]interface{}{{int64(1)}},
+		},
 		{
 			name:         "nested with",
 			query:        `WITH output AS ( WITH sub AS ( SELECT val FROM UNNEST([1, 2, 3]) as val ) SELECT * FROM sub WHERE val > 1 ) SELECT * FROM output`,
 			expectedRows: [][]interface{}{{int64(2)}, {int64(3)}},
+		},
+		{
+			name: "nested with 2",
+			query: `
+WITH tmp as (
+  WITH A AS (
+    SELECT * FROM (SELECT 1 AS id)
+  ), B AS (
+    SELECT * FROM (SELECT "hello" AS name)
+  ) SELECT * FROM A CROSS JOIN B
+) SELECT * FROM tmp
+`,
+			expectedRows: [][]interface{}{{int64(1), "hello"}},
 		},
 	} {
 		test := test


### PR DESCRIPTION
fix https://github.com/goccy/bigquery-emulator/issues/125

In SQLite, `with` clause cannot be used in subquery, so modify it to combine with top level `with` clause.