### PR TITLE
Like: Wildcard error fix

### DIFF
--- a/internal/function.go
+++ b/internal/function.go
@@ -214,7 +214,9 @@ func LIKE(a, b Value) (Value, error) {
 	if err != nil {
 		return nil, err
 	}
-	re, err := regexp.Compile(strings.Replace(vb, "%", "*", -1))
+	wildcard := strings.Replace(vb, "%", ".*", -1)
+	matchLimits := fmt.Sprintf("^%s$", wildcard)
+	re, err := regexp.Compile(matchLimits)
 	if err != nil {
 		return nil, err
 	}

--- a/query_test.go
+++ b/query_test.go
@@ -157,6 +157,21 @@ func TestQuery(t *testing.T) {
 			expectedRows: [][]interface{}{{true}},
 		},
 		{
+			name:         "like operator2",
+			query:        `SELECT "abcd" LIKE "%a%"`,
+			expectedRows: [][]interface{}{{true}},
+		},
+		{
+			name:         "like operator3",
+			query:        `SELECT "abcd" LIKE "%b%"`,
+			expectedRows: [][]interface{}{{true}},
+		},
+		{
+			name:         "like operator4",
+			query:        `SELECT "dog" LIKE "o%"`,
+			expectedRows: [][]interface{}{{false}},
+		},
+		{
 			name:         "not like operator",
 			query:        `SELECT "abcd" NOT LIKE "a%d"`,
 			expectedRows: [][]interface{}{{false}},


### PR DESCRIPTION
Fixes two bugs related to the `Like` Operator:


1. queries like: `SELECT "abcd" LIKE "%a%` ends up in the error below:
```
error parsing regexp: missing argument to repetition operator: `*`
```

Fix: instead of replacing `%` -> `*`, now we replace : `%` -> `.*`


2.  A query like below should result in `false`, but currently returns `true`
  ```sql
  SELECT "dog" LIKE "o%
  ```
  
Fix:  added `^` and `$` to fix this bug