### PR TITLE
 @nsfinkelstein Update functionality of COALESCE to match zetasql 

### DIFF
--- a/internal/function.go
+++ b/internal/function.go
@@ -359,7 +359,7 @@ func COALESCE(args ...Value) (Value, error) {
 		}
 		return arg, nil
 	}
-	return nil, fmt.Errorf("COALESCE required arguments")
+	return nil, nil
 }
 
 func IF(cond, trueV, falseV Value) (Value, error) {

--- a/internal/function.go
+++ b/internal/function.go
@@ -359,7 +359,7 @@ func COALESCE(args ...Value) (Value, error) {
 		}
 		return arg, nil
 	}
-	return nil, fmt.Errorf("COALESCE requried arguments")
+	return nil, fmt.Errorf("COALESCE required arguments")
 }
 
 func IF(cond, trueV, falseV Value) (Value, error) {

--- a/query_test.go
+++ b/query_test.go
@@ -434,6 +434,11 @@ FROM UNNEST([1, 2, 3, 4]) AS val`,
 			expectedRows: [][]interface{}{{"B"}},
 		},
 		{
+			name:         "coalesce with all nulls",
+			query:        `SELECT COALESCE(NULL, NULL, NULL)`,
+			expectedRows: [][]interface{}{{nil}},
+		},
+		{
 			name:         "if return int64",
 			query:        `SELECT IF("a" = "b", 1, 2)`,
 			expectedRows: [][]interface{}{{int64(2)}},


### PR DESCRIPTION
COALESCE returns null if all args are null, but this implementation throws an error if all args are null.

This pull request brings this implementation in line with zetasql behavior.