### PR TITLE
Add timezone parser for 'Ez' format

### DIFF
--- a/query_test.go
+++ b/query_test.go
@@ -3888,6 +3888,11 @@ SELECT date, EXTRACT(ISOYEAR FROM date), EXTRACT(YEAR FROM date), EXTRACT(MONTH 
 			expectedRows: [][]interface{}{{createTimestampFormatFromString("2008-12-25 07:30:00+00")}},
 		},
 		{
+			name:         "parse timestamp with %Y-%m-%d %H:%M:%S%Ez",
+			query:        `SELECT PARSE_TIMESTAMP("%Y-%m-%d %H:%M:%S%Ez", "2020-06-02 23:58:40+09:00")`,
+			expectedRows: [][]interface{}{{createTimestampFormatFromString("2020-06-02 14:58:40+00")}},
+		},
+		{
 			name:        "parse timestamp ( the year element is in different locations )",
 			query:       `SELECT PARSE_TIMESTAMP("%a %b %e %Y %I:%M:%S", "Thu Dec 25 07:30:00 2008")`,
 			expectedErr: "unexpected year number",


### PR DESCRIPTION
I would like to add extended time format such as 'Ez' or 'E*S'. [(ref)](https://cloud.google.com/bigquery/docs/reference/standard-sql/format-elements?hl=ja#format_elements_date_time)
As a first step, I implemented 'Ez' format.