### PR TITLE
Fix array function format

### DIFF
--- a/internal/formatter.go
+++ b/internal/formatter.go
@@ -592,7 +592,7 @@ func (n *SubqueryExprNode) FormatSQL(ctx context.Context) (string, error) {
 			return "", fmt.Errorf("failed to find computed column names for array subquery")
 		}
 		colName := uniqueColumnName(ctx, n.node.Subquery().ColumnList()[0])
-		return fmt.Sprintf("zetasqlite_array(`%s`) FROM (%s)", colName, sql), nil
+		return fmt.Sprintf("(SELECT zetasqlite_array(`%s`) FROM (%s))", colName, sql), nil
 	case ast.SubqueryTypeExists:
 		return fmt.Sprintf("EXISTS (%s)", sql), nil
 	case ast.SubqueryTypeIn:

--- a/query_test.go
+++ b/query_test.go
@@ -2139,6 +2139,22 @@ FROM UNNEST([
 			},
 		},
 		{
+			name: "array function with other column",
+			query: `
+SELECT ARRAY (
+	SELECT 1
+) AS new_array,
+1 as new_column
+`,
+			expectedRows: [][]interface{}{
+				{
+					[]interface{}{
+						int64(1),
+					},
+					int64(1),
+				},
+			},
+		}, {
 			name:  "array_concat function",
 			query: `SELECT ARRAY_CONCAT([1, 2], [3, 4], [5, 6]) as count_to_six`,
 			expectedRows: [][]interface{}{


### PR DESCRIPTION
As mentioned [this issue](https://github.com/goccy/bigquery-emulator/issues/157), calling array function with other columns had been failed. 
This is because formatted query has a FROM clause in line with zetasqlite_array.

Raw query:
```
SELECT
    ARRAY (SELECT 1) AS new_array,
    1 as new_column
```

Formatted query (current):
```
SELECT
    zetasqlite_array(`$col1#1`)
FROM (
    SELECT 1 AS `$col1#1` 
) AS `new_array#2`,
1 AS `new_column#3` // syntax error
```

So I added additional SELECT statement.

Formatted query (fixed):
```
SELECT (
    SELECT 
        zetasqlite_array(`$col1#1`) 
    FROM (
        SELECT 1 AS `$col1#1` 
    )
) AS `new_array#2`,
1 AS `new_column#3` 
```

Could you please check this PR when you have time? @goccy 