### PR TITLE
fix TABLE_SUFFIX query

### DIFF
--- a/exec_test.go
+++ b/exec_test.go
@@ -250,41 +250,80 @@ func TestWildcardTable(t *testing.T) {
 	); err != nil {
 		t.Fatal(err)
 	}
-	rows, err := db.QueryContext(ctx, "SELECT name, _TABLE_SUFFIX FROM `project.dataset.table_*` WHERE name LIKE 'alice%' OR name IS NULL")
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer rows.Close()
-	type queryRow struct {
-		Name   *string
-		Suffix string
-	}
-	var results []*queryRow
-	for rows.Next() {
-		var (
-			name   *string
-			suffix string
-		)
-		if err := rows.Scan(&name, &suffix); err != nil {
+	t.Run("with first identifier", func(t *testing.T) {
+		rows, err := db.QueryContext(ctx, "SELECT name, _TABLE_SUFFIX FROM `project.dataset.table_*` WHERE name LIKE 'alice%' OR name IS NULL")
+		if err != nil {
 			t.Fatal(err)
 		}
-		results = append(results, &queryRow{
-			Name:   name,
-			Suffix: suffix,
-		})
-	}
-	if err := rows.Err(); err != nil {
-		t.Fatal(err)
-	}
-	stringPtr := func(v string) *string { return &v }
-	if diff := cmp.Diff(results, []*queryRow{
-		{Name: stringPtr("alice_c"), Suffix: "c"},
-		{Name: stringPtr("alice_b"), Suffix: "b"},
-		{Name: nil, Suffix: "a"},
-		{Name: nil, Suffix: "a"},
-	}); diff != "" {
-		t.Errorf("(-want +got):\n%s", diff)
-	}
+		defer rows.Close()
+		type queryRow struct {
+			Name   *string
+			Suffix string
+		}
+		var results []*queryRow
+		for rows.Next() {
+			var (
+				name   *string
+				suffix string
+			)
+			if err := rows.Scan(&name, &suffix); err != nil {
+				t.Fatal(err)
+			}
+			results = append(results, &queryRow{
+				Name:   name,
+				Suffix: suffix,
+			})
+		}
+		if err := rows.Err(); err != nil {
+			t.Fatal(err)
+		}
+		stringPtr := func(v string) *string { return &v }
+		if diff := cmp.Diff(results, []*queryRow{
+			{Name: stringPtr("alice_c"), Suffix: "c"},
+			{Name: stringPtr("alice_b"), Suffix: "b"},
+			{Name: nil, Suffix: "a"},
+			{Name: nil, Suffix: "a"},
+		}); diff != "" {
+			t.Errorf("(-want +got):\n%s", diff)
+		}
+	})
+	t.Run("without first identifier", func(t *testing.T) {
+		rows, err := db.QueryContext(ctx, "SELECT name, _TABLE_SUFFIX FROM `dataset.table_*` WHERE name LIKE 'alice%' OR name IS NULL")
+		if err != nil {
+			t.Fatal(err)
+		}
+		defer rows.Close()
+		type queryRow struct {
+			Name   *string
+			Suffix string
+		}
+		var results []*queryRow
+		for rows.Next() {
+			var (
+				name   *string
+				suffix string
+			)
+			if err := rows.Scan(&name, &suffix); err != nil {
+				t.Fatal(err)
+			}
+			results = append(results, &queryRow{
+				Name:   name,
+				Suffix: suffix,
+			})
+		}
+		if err := rows.Err(); err != nil {
+			t.Fatal(err)
+		}
+		stringPtr := func(v string) *string { return &v }
+		if diff := cmp.Diff(results, []*queryRow{
+			{Name: stringPtr("alice_c"), Suffix: "c"},
+			{Name: stringPtr("alice_b"), Suffix: "b"},
+			{Name: nil, Suffix: "a"},
+			{Name: nil, Suffix: "a"},
+		}); diff != "" {
+			t.Errorf("(-want +got):\n%s", diff)
+		}
+	})
 }
 
 func TestTemplatedArgFunc(t *testing.T) {

--- a/internal/wildcard_table.go
+++ b/internal/wildcard_table.go
@@ -175,9 +175,15 @@ func (c *Catalog) createWildcardTable(path []string) (types.Table, error) {
 	wildcardTable.NamePath[len(spec.NamePath)-1] = fmt.Sprintf(
 		"%s_wildcard_%d", lastNamePath, time.Now().Unix(),
 	)
+	projectID := spec.NamePath[0]
+	prefix := name
+	if !strings.HasPrefix(prefix, projectID+".") {
+		prefix = projectID + "." + prefix
+	}
+
 	return &WildcardTable{
 		spec:   wildcardTable,
 		tables: matchedSpecs,
-		prefix: name,
+		prefix: prefix,
 	}, nil
 }

--- a/internal/wildcard_table.go
+++ b/internal/wildcard_table.go
@@ -175,10 +175,12 @@ func (c *Catalog) createWildcardTable(path []string) (types.Table, error) {
 	wildcardTable.NamePath[len(spec.NamePath)-1] = fmt.Sprintf(
 		"%s_wildcard_%d", lastNamePath, time.Now().Unix(),
 	)
-	projectID := spec.NamePath[0]
+
+	// firstIdentifier may be omitted, so we need to check it.
 	prefix := name
-	if !strings.HasPrefix(prefix, projectID+".") {
-		prefix = projectID + "." + prefix
+	firstIdentifier := spec.NamePath[0]
+	if !strings.HasPrefix(prefix, firstIdentifier+".") {
+		prefix = firstIdentifier + "." + prefix
 	}
 
 	return &WildcardTable{


### PR DESCRIPTION
Currently, we cannot obtain TABLE_SUFFIX correctly when query doesn't contain ProjectID like `SELECT _TABLE_SUFFIX FROM dataset.table_*`.

This is because `WildcardTable.prefix` doesn't consider ProjectID. 

So I added ProjectID to prefix if it's absent.