### PR TITLE
Add time format

### DIFF
--- a/internal/encoder.go
+++ b/internal/encoder.go
@@ -232,19 +232,19 @@ func dateValueFromLiteral(days int64) (DateValue, error) {
 }
 
 const (
-	microSecondShift = 20
-	secShift         = 0
-	minShift         = 6
-	hourShift        = 12
-	dayShift         = 17
-	monthShift       = 22
-	yearShift        = 26
-	secMask          = 0b111111
-	minMask          = 0b111111 << minShift
-	hourMask         = 0b11111 << hourShift
-	dayMask          = 0b11111 << dayShift
-	monthMask        = 0b1111 << monthShift
-	yearMask         = 0x3FFF << yearShift
+	secShift     = 0
+	minShift     = 6
+	hourShift    = 12
+	dayShift     = 17
+	monthShift   = 22
+	yearShift    = 26
+	microSecMask = 0xFFFFF
+	secMask      = 0b111111
+	minMask      = 0b111111 << minShift
+	hourMask     = 0b11111 << hourShift
+	dayMask      = 0b11111 << dayShift
+	monthMask    = 0b1111 << monthShift
+	yearMask     = 0x3FFF << yearShift
 )
 
 func datetimeValueFromLiteral(bit int64) (DatetimeValue, error) {
@@ -255,6 +255,7 @@ func datetimeValueFromLiteral(bit int64) (DatetimeValue, error) {
 	hour := (b & hourMask) >> hourShift
 	min := (b & minMask) >> minShift
 	sec := (b & secMask) >> secShift
+	microSec := (bit & microSecMask) >> 0
 	t := time.Date(
 		int(year),
 		time.Month(month),
@@ -262,7 +263,7 @@ func datetimeValueFromLiteral(bit int64) (DatetimeValue, error) {
 		int(hour),
 		int(min),
 		int(sec),
-		0, time.UTC,
+		int(microSec)*1000, time.UTC,
 	)
 	return DatetimeValue(t), nil
 }
@@ -272,7 +273,8 @@ func timeValueFromLiteral(bit int64) (TimeValue, error) {
 	hour := (b & hourMask) >> hourShift
 	min := (b & minMask) >> minShift
 	sec := (b & secMask) >> secShift
-	t := time.Date(0, 0, 0, int(hour), int(min), int(sec), 0, time.UTC)
+	microSec := (bit & microSecMask) >> 0
+	t := time.Date(0, 0, 0, int(hour), int(min), int(sec), int(microSec)*1000, time.UTC)
 	return TimeValue(t), nil
 }
 

--- a/internal/value.go
+++ b/internal/value.go
@@ -1841,7 +1841,7 @@ func (t TimeValue) ToInt64() (int64, error) {
 }
 
 func (t TimeValue) ToString() (string, error) {
-	return time.Time(t).Format("15:04:05"), nil
+	return time.Time(t).Format("15:04:05.999999"), nil
 }
 
 func (t TimeValue) ToBytes() ([]byte, error) {
@@ -1881,7 +1881,7 @@ func (t TimeValue) ToRat() (*big.Rat, error) {
 }
 
 func (t TimeValue) Format(verb rune) string {
-	formatted := time.Time(t).Format("15:04:05")
+	formatted := time.Time(t).Format("15:04:05.999999")
 	switch verb {
 	case 't':
 		return formatted
@@ -1892,7 +1892,7 @@ func (t TimeValue) Format(verb rune) string {
 }
 
 func (t TimeValue) Interface() interface{} {
-	return time.Time(t).Format("15:04:05")
+	return time.Time(t).Format("15:04:05.999999")
 }
 
 type TimestampValue time.Time

--- a/query_test.go
+++ b/query_test.go
@@ -3596,6 +3596,12 @@ SELECT date, EXTRACT(ISOYEAR FROM date), EXTRACT(YEAR FROM date), EXTRACT(MONTH 
 			expectedRows: [][]interface{}{{"Dec 2008"}},
 		},
 		{
+			name:         "format_date with %E4Y",
+			query:        `SELECT FORMAT_DATE("%E4Y", DATE "2008-12-25")`,
+			expectedRows: [][]interface{}{{"2008"}},
+		},
+
+		{
 			name:         "last_day",
 			query:        `SELECT LAST_DAY(DATE '2008-11-25') AS last_day`,
 			expectedRows: [][]interface{}{{"2008-11-30"}},
@@ -3736,6 +3742,21 @@ SELECT date, EXTRACT(ISOYEAR FROM date), EXTRACT(YEAR FROM date), EXTRACT(MONTH 
 			expectedRows: [][]interface{}{{"Dec 2008"}},
 		},
 		{
+			name:         "format_datetime with %E3S",
+			query:        `SELECT FORMAT_DATETIME("%E3S", DATETIME "2008-12-25 15:30:12.345678")`,
+			expectedRows: [][]interface{}{{"12.345"}},
+		},
+		{
+			name:         "format_datetime with %E*S",
+			query:        `SELECT FORMAT_DATETIME("%E*S", DATETIME "2008-12-25 15:30:12.345678")`,
+			expectedRows: [][]interface{}{{"12.345678"}},
+		},
+		{
+			name:         "format_datetime with %E4Y",
+			query:        `SELECT FORMAT_DATETIME("%E4Y", DATETIME "2008-12-25 15:30:12.345678")`,
+			expectedRows: [][]interface{}{{"2008"}},
+		},
+		{
 			name:         "parse datetime",
 			query:        `SELECT PARSE_DATETIME("%a %b %e %I:%M:%S %Y", "Thu Dec 25 07:30:00 2008")`,
 			expectedRows: [][]interface{}{{"2008-12-25T07:30:00"}},
@@ -3761,7 +3782,7 @@ SELECT date, EXTRACT(ISOYEAR FROM date), EXTRACT(YEAR FROM date), EXTRACT(MONTH 
 			name:  "current_time",
 			query: `SELECT CURRENT_TIME()`,
 			expectedRows: [][]interface{}{
-				{now.Format("15:04:05")},
+				{now.Format("15:04:05.999999")},
 			},
 		},
 		{
@@ -3800,6 +3821,16 @@ SELECT date, EXTRACT(ISOYEAR FROM date), EXTRACT(YEAR FROM date), EXTRACT(MONTH 
 			name:         "format_time with %R",
 			query:        `SELECT FORMAT_TIME("%R", TIME "15:30:00")`,
 			expectedRows: [][]interface{}{{"15:30"}},
+		},
+		{
+			name:         "format_time with %E3S",
+			query:        `SELECT FORMAT_TIME("%E3S", TIME "15:30:12.345678")`,
+			expectedRows: [][]interface{}{{"12.345"}},
+		},
+		{
+			name:         "format_time with %E*S",
+			query:        `SELECT FORMAT_TIME("%E*S", TIME "15:30:12.345678")`,
+			expectedRows: [][]interface{}{{"12.345678"}},
 		},
 		{
 			name:         "parse time with %I:%M:%S",
@@ -3924,6 +3955,26 @@ SELECT date, EXTRACT(ISOYEAR FROM date), EXTRACT(YEAR FROM date), EXTRACT(MONTH 
 			expectedRows: [][]interface{}{{"2008-12-26 00:30:21"}},
 		},
 		{
+			name:         "format_timestamp with %E3S",
+			query:        `SELECT FORMAT_TIMESTAMP("%E3S", TIMESTAMP "2008-12-25 15:30:12.345678+00")`,
+			expectedRows: [][]interface{}{{"12.345"}},
+		},
+		{
+			name:         "format_timestamp with %E*S",
+			query:        `SELECT FORMAT_TIMESTAMP("%E*S", TIMESTAMP "2008-12-25 15:30:12.345678+00")`,
+			expectedRows: [][]interface{}{{"12.345678"}},
+		},
+		{
+			name:         "format_timestamp with %E4Y",
+			query:        `SELECT FORMAT_TIMESTAMP("%E4Y", TIMESTAMP "2008-12-25 15:30:12.345678+00")`,
+			expectedRows: [][]interface{}{{"2008"}},
+		},
+		{
+			name:         "format_timestamp with %Ez",
+			query:        `SELECT FORMAT_TIMESTAMP("%Ez", TIMESTAMP "2008-12-25 15:30:12.345678+00")`,
+			expectedRows: [][]interface{}{{"+00:00"}},
+		},
+		{
 			name:         "parse timestamp with %a %b %e %I:%M:%S %Y",
 			query:        `SELECT PARSE_TIMESTAMP("%a %b %e %I:%M:%S %Y", "Thu Dec 25 07:30:00 2008")`,
 			expectedRows: [][]interface{}{{createTimestampFormatFromString("2008-12-25 07:30:00+00")}},
@@ -3993,7 +4044,7 @@ SELECT
   DATETIME "2021-06-01 12:34:56.789" - DATETIME "2021-05-31 00:00:00",
   TIMESTAMP "2021-06-01 12:34:56.789" - TIMESTAMP "2021-05-31 00:00:00"`,
 			expectedRows: [][]interface{}{
-				{"0-0 396 0:0:0", "0-0 0 36:34:56", "0-0 0 36:34:56.789"},
+				{"0-0 396 0:0:0", "0-0 0 36:34:56.789", "0-0 0 36:34:56.789"},
 			},
 		},
 		{


### PR DESCRIPTION
Support "%E[1-6]S" "%E*S" "%Ez" for `FORMAT` function.

ref https://github.com/goccy/bigquery-emulator/issues/168
