### PR TITLE
Update sqlite3

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.17
 
 require (
 	github.com/goccy/go-zetasql v0.5.1
-	github.com/mattn/go-sqlite3 v1.14.14
+	github.com/mattn/go-sqlite3 v1.14.16
 )
 
 require github.com/google/go-cmp v0.5.8

--- a/go.sum
+++ b/go.sum
@@ -219,8 +219,8 @@ github.com/kr/pretty v0.3.0/go.mod h1:640gp4NfQd8pI5XOwp5fnNeVWj67G7CFk/SaSQn7NB
 github.com/kr/pty v1.1.1/go.mod h1:pFQYn66WHrOpPYNljwOMqo10TkYh1fy3cYio2l3bCsQ=
 github.com/kr/text v0.1.0/go.mod h1:4Jbv+DJW3UT/LiOwJeYQe1efqtUx/iVham/4vfdArNI=
 github.com/kr/text v0.2.0/go.mod h1:eLer722TekiGuMkidMxC/pM04lWEeraHUUmBw8l2grE=
-github.com/mattn/go-sqlite3 v1.14.14 h1:qZgc/Rwetq+MtyE18WhzjokPD93dNqLGNT3QJuLvBGw=
-github.com/mattn/go-sqlite3 v1.14.14/go.mod h1:NyWgC/yNuGj7Q9rpYnZvas74GogHl5/Z4A/KQRfk6bU=
+github.com/mattn/go-sqlite3 v1.14.16 h1:yOQRA0RpS5PFz/oikGwBEqvAWhWg5ufRz4ETLjwpU1Y=
+github.com/mattn/go-sqlite3 v1.14.16/go.mod h1:2eHXhiwb8IkHr+BDWZGa96P6+rkvnG63S2DGjv9HUNg=
 github.com/pkg/errors v0.8.0 h1:WdK/asTD0HN+q6hsWO3/vpuAkAr+tw6aNJNDFFf0+qw=
 github.com/pkg/errors v0.8.0/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=

--- a/internal/context.go
+++ b/internal/context.go
@@ -218,18 +218,6 @@ func tableNameToColumnListMap(ctx context.Context) map[string][]*ast.Column {
 	return value.(map[string][]*ast.Column)
 }
 
-func withRowIDColumn(ctx context.Context) context.Context {
-	return context.WithValue(ctx, rowIDColumnKey{}, true)
-}
-
-func needsRowIDColumn(ctx context.Context) bool {
-	value := ctx.Value(rowIDColumnKey{})
-	if value == nil {
-		return false
-	}
-	return value.(bool)
-}
-
 func WithCurrentTime(ctx context.Context, now time.Time) context.Context {
 	return context.WithValue(ctx, currentTimeKey{}, &now)
 }

--- a/internal/formatter.go
+++ b/internal/formatter.go
@@ -659,7 +659,7 @@ func (n *JoinScanNode) FormatSQL(ctx context.Context) (string, error) {
 	if n.node == nil {
 		return "", nil
 	}
-	left, err := newNode(n.node.LeftScan()).FormatSQL(withRowIDColumn(ctx))
+	left, err := newNode(n.node.LeftScan()).FormatSQL(ctx)
 	if err != nil {
 		return "", err
 	}
@@ -686,30 +686,9 @@ func (n *JoinScanNode) FormatSQL(ctx context.Context) (string, error) {
 	case ast.JoinTypeLeft:
 		return fmt.Sprintf("%s LEFT JOIN %s ON %s", left, right, joinExpr), nil
 	case ast.JoinTypeRight:
-		// SQLite doesn't support RIGHT JOIN at v3.38.0, so emulate by using LEFT JOIN.
-		// ROW_NUMBER() OVER() AS `row_id`
-		return fmt.Sprintf("%s LEFT JOIN %s ON %s ORDER BY `row_id` NULLS LAST", right, left, joinExpr), nil
+		return fmt.Sprintf("%s RIGHT JOIN %s ON %s", left, right, joinExpr), nil
 	case ast.JoinTypeFull:
-		// SQLite doesn't support FULL OUTER JOIN at v3.38.0,
-		// so emulate by combination of LEFT JOIN and UNION ALL and DISTINCT.
-		var (
-			columns   []string
-			columnMap = columnRefMap(ctx)
-		)
-		for _, col := range n.node.ColumnList() {
-			colName := uniqueColumnName(ctx, col)
-			if ref, exists := columnMap[colName]; exists {
-				columns = append(columns, ref)
-				delete(columnMap, colName)
-			} else {
-				columns = append(columns, fmt.Sprintf("`%s`", colName))
-			}
-		}
-		return fmt.Sprintf(
-			"SELECT DISTINCT %[1]s FROM (SELECT %[1]s FROM %[2]s LEFT JOIN %[3]s ON %[4]s UNION ALL SELECT %[1]s FROM %[3]s LEFT JOIN %[2]s ON %[4]s)",
-			strings.Join(columns, ","),
-			left, right, joinExpr,
-		), nil
+		return fmt.Sprintf("%s FULL OUTER JOIN %s ON %s", left, right, joinExpr), nil
 	}
 	return "", fmt.Errorf("unexpected join type %d", n.node.JoinType())
 }
@@ -815,12 +794,6 @@ func (n *AggregateScanNode) FormatSQL(ctx context.Context) (string, error) {
 		} else {
 			columns = append(columns, fmt.Sprintf("`%s`", colName))
 		}
-	}
-	if needsRowIDColumn(ctx) {
-		columns = append(
-			columns,
-			"ROW_NUMBER() OVER() AS `row_id`",
-		)
 	}
 	if len(n.node.GroupingSetList()) != 0 {
 		columnPatterns := [][]string{}
@@ -1096,12 +1069,6 @@ func (n *WithRefScanNode) FormatSQL(ctx context.Context) (string, error) {
 			fmt.Sprintf("`%s` AS `%s`", uniqueColumnName(ctx, columnDefs[i]), uniqueColumnName(ctx, columns[i])),
 		)
 	}
-	if needsRowIDColumn(ctx) {
-		formattedColumns = append(
-			formattedColumns,
-			"ROW_NUMBER() OVER() AS `row_id`",
-		)
-	}
 	return fmt.Sprintf("(SELECT %s FROM `%s`)", strings.Join(formattedColumns, ","), tableName), nil
 }
 
@@ -1291,12 +1258,6 @@ func (n *ProjectScanNode) FormatSQL(ctx context.Context) (string, error) {
 				fmt.Sprintf("`%s`", colName),
 			)
 		}
-	}
-	if needsRowIDColumn(ctx) {
-		columns = append(
-			columns,
-			"ROW_NUMBER() OVER() AS `row_id`",
-		)
 	}
 	formattedInput, err := formatInput(input)
 	if err != nil {


### PR DESCRIPTION
go-sqlite3 supports v3.39.0. That version supported RIGHT JOIN and FULL OUTER JOIN.