### PR TITLE
Update format when casting date/times to strings

### DIFF
--- a/internal/encoder.go
+++ b/internal/encoder.go
@@ -378,7 +378,25 @@ func CastValue(t types.Type, v Value) (Value, error) {
 			return nil, err
 		}
 		return FloatValue(f64), nil
-	case types.STRING, types.ENUM:
+	case types.STRING:
+		switch v.(type) {
+		// If this is coming from a date/time, the format is slightly different
+		// than when just writing the value out as a string.
+		case DateValue:
+			return convertTimeValueToStringWithFormat(v, "2006-01-02")
+		case DatetimeValue:
+			return convertTimeValueToStringWithFormat(v, "2006-01-02 15:04:05.999999")
+		case TimeValue:
+			return convertTimeValueToStringWithFormat(v, "15:04:05.999999")
+		case TimestampValue:
+			return convertTimeValueToStringWithFormat(v, "2006-01-02 15:04:05.999999-07")
+		}
+		s, err := v.ToString()
+		if err != nil {
+			return nil, err
+		}
+		return StringValue(s), nil
+	case types.ENUM:
 		s, err := v.ToString()
 		if err != nil {
 			return nil, err
@@ -505,6 +523,14 @@ func CastValue(t types.Type, v Value) (Value, error) {
 		return v, nil
 	}
 	return nil, fmt.Errorf("unsupported cast %s value", t.Kind())
+}
+
+func convertTimeValueToStringWithFormat(v Value, format string) (Value, error) {
+	valueTime, err := v.ToTime()
+	if err != nil {
+		return nil, err
+	}
+	return StringValue(valueTime.UTC().Format(format)), nil
 }
 
 func ValueFromGoValue(v interface{}) (Value, error) {

--- a/internal/encoder.go
+++ b/internal/encoder.go
@@ -379,18 +379,6 @@ func CastValue(t types.Type, v Value) (Value, error) {
 		}
 		return FloatValue(f64), nil
 	case types.STRING:
-		switch v.(type) {
-		// If this is coming from a date/time, the format is slightly different
-		// than when just writing the value out as a string.
-		case DateValue:
-			return convertTimeValueToStringWithFormat(v, "2006-01-02")
-		case DatetimeValue:
-			return convertTimeValueToStringWithFormat(v, "2006-01-02 15:04:05.999999")
-		case TimeValue:
-			return convertTimeValueToStringWithFormat(v, "15:04:05.999999")
-		case TimestampValue:
-			return convertTimeValueToStringWithFormat(v, "2006-01-02 15:04:05.999999-07")
-		}
 		s, err := v.ToString()
 		if err != nil {
 			return nil, err
@@ -523,14 +511,6 @@ func CastValue(t types.Type, v Value) (Value, error) {
 		return v, nil
 	}
 	return nil, fmt.Errorf("unsupported cast %s value", t.Kind())
-}
-
-func convertTimeValueToStringWithFormat(v Value, format string) (Value, error) {
-	valueTime, err := v.ToTime()
-	if err != nil {
-		return nil, err
-	}
-	return StringValue(valueTime.UTC().Format(format)), nil
 }
 
 func ValueFromGoValue(v interface{}) (Value, error) {

--- a/internal/function_datetime.go
+++ b/internal/function_datetime.go
@@ -100,7 +100,7 @@ func DATETIME(args ...Value) (Value, error) {
 			}
 			return DatetimeValue(t.In(loc)), nil
 		}
-		return DatetimeValue(t), nil
+		return DatetimeValue(t.UTC()), nil
 	}
 	return nil, fmt.Errorf("DATETIME: first argument must be DATE or TIMESTAMP type")
 }

--- a/internal/function_time.go
+++ b/internal/function_time.go
@@ -57,13 +57,13 @@ func TIME(args ...Value) (Value, error) {
 			}
 			return TimeValue(t.In(loc)), nil
 		}
-		return TimeValue(t), nil
+		return TimeValue(t.UTC()), nil
 	case DatetimeValue:
 		t, err := args[0].ToTime()
 		if err != nil {
 			return nil, err
 		}
-		return TimeValue(t), nil
+		return TimeValue(t.UTC()), nil
 	}
 	return nil, fmt.Errorf("TIME: invalid first argument type %T", args[0])
 }

--- a/internal/rows.go
+++ b/internal/rows.go
@@ -5,12 +5,10 @@ import (
 	"database/sql"
 	"database/sql/driver"
 	"fmt"
-	"io"
-	"reflect"
-	"time"
-
 	"github.com/goccy/go-json"
 	"github.com/goccy/go-zetasql/types"
+	"io"
+	"reflect"
 )
 
 type Rows struct {
@@ -232,68 +230,65 @@ func (r *Rows) assignInterfaceValue(src Value, dst reflect.Value, typ *Type) err
 		}
 		dst.Set(reflect.ValueOf(f64))
 	case types.BYTES:
-		s, err := src.ToString()
+		s, err := src.ToApiString()
 		if err != nil {
 			return err
 		}
 		dst.Set(reflect.ValueOf(s))
 	case types.STRING:
-		s, err := src.ToString()
+		s, err := src.ToApiString()
 		if err != nil {
 			return err
 		}
 		dst.Set(reflect.ValueOf(s))
 	case types.NUMERIC:
-		s, err := src.ToString()
+		s, err := src.ToApiString()
 		if err != nil {
 			return err
 		}
 		dst.Set(reflect.ValueOf(s))
 	case types.BIG_NUMERIC:
-		s, err := src.ToString()
+		s, err := src.ToApiString()
 		if err != nil {
 			return err
 		}
 		dst.Set(reflect.ValueOf(s))
 	case types.DATE:
-		date, err := src.ToJSON()
+		date, err := src.ToApiString()
 		if err != nil {
 			return err
 		}
 		dst.Set(reflect.ValueOf(date))
 	case types.DATETIME:
-		datetime, err := src.ToJSON()
+		datetime, err := src.ToApiString()
 		if err != nil {
 			return err
 		}
 		dst.Set(reflect.ValueOf(datetime))
 	case types.TIME:
-		time, err := src.ToJSON()
+		time, err := src.ToApiString()
 		if err != nil {
 			return err
 		}
 		dst.Set(reflect.ValueOf(time))
 	case types.TIMESTAMP:
-		t, err := src.ToTime()
+		t, err := src.ToApiString()
 		if err != nil {
 			return err
 		}
-		unixmicro := t.UnixMicro()
-		sec := unixmicro / int64(time.Millisecond)
-		nsec := unixmicro - sec*int64(time.Millisecond)
-		dst.Set(reflect.ValueOf(fmt.Sprintf("%d.%d", sec, nsec)))
+		dst.Set(reflect.ValueOf(t))
 	case types.INTERVAL:
-		s, err := src.ToString()
+		s, err := src.ToApiString()
 		if err != nil {
 			return err
 		}
 		dst.Set(reflect.ValueOf(s))
 	case types.JSON:
-		json, err := src.ToJSON()
+		j, err := src.ToApiString()
 		if err != nil {
 			return err
 		}
-		dst.Set(reflect.ValueOf(json))
+		dst.Set(reflect.ValueOf(j))
 	case types.STRUCT:
 		s, err := src.ToStruct()
 		if err != nil {

--- a/query_test.go
+++ b/query_test.go
@@ -3707,6 +3707,12 @@ SELECT date, EXTRACT(ISOYEAR FROM date), EXTRACT(YEAR FROM date), EXTRACT(MONTH 
 		},
 
 		{
+			name:         "cast date as string",
+			query:        `SELECT CAST(DATE("2022-08-01 06:47:51.123456-07:00") AS STRING)`,
+			expectedRows: [][]interface{}{{"2022-08-01"}},
+		},
+
+		{
 			name:         "last_day",
 			query:        `SELECT LAST_DAY(DATE '2008-11-25') AS last_day`,
 			expectedRows: [][]interface{}{{"2008-11-30"}},
@@ -3877,6 +3883,16 @@ SELECT date, EXTRACT(ISOYEAR FROM date), EXTRACT(YEAR FROM date), EXTRACT(MONTH 
 			expectedRows: [][]interface{}{{"2008"}},
 		},
 		{
+			name:         "cast datetime as string",
+			query:        `SELECT CAST(DATETIME(TIMESTAMP("2022-08-01 06:47:51.123456-07:00")) AS STRING)`,
+			expectedRows: [][]interface{}{{"2022-08-01 13:47:51.123456"}},
+		},
+		{
+			name:         "cast date as datetime",
+			query:        `SELECT CAST(DATE("1987-01-25") AS DATETIME)`,
+			expectedRows: [][]interface{}{{"1987-01-25T00:00:00"}},
+		},
+		{
 			name:         "parse datetime",
 			query:        `SELECT PARSE_DATETIME("%a %b %e %I:%M:%S %Y", "Thu Dec 25 07:30:00 2008")`,
 			expectedRows: [][]interface{}{{"2008-12-25T07:30:00"}},
@@ -3951,6 +3967,21 @@ SELECT date, EXTRACT(ISOYEAR FROM date), EXTRACT(YEAR FROM date), EXTRACT(MONTH 
 			name:         "format_time with %E*S",
 			query:        `SELECT FORMAT_TIME("%E*S", TIME "15:30:12.345678")`,
 			expectedRows: [][]interface{}{{"12.345678"}},
+		},
+		{
+			name:         "cast time as string",
+			query:        `SELECT CAST(TIME("2022-08-01 06:47:51.123456-04:00") AS STRING)`,
+			expectedRows: [][]interface{}{{"10:47:51.123456"}},
+		},
+		{
+			name:         "cast time with timezone as string",
+			query:        `SELECT CAST(TIME("2022-08-01 06:47:51.123456-04:00", "America/Los_Angeles") AS STRING)`,
+			expectedRows: [][]interface{}{{"03:47:51.123456"}},
+		},
+		{
+			name:         "cast time from datetime as string",
+			query:        `SELECT CAST(TIME(DATETIME(TIMESTAMP("2022-08-01 06:47:51.123456-04:00"))) AS STRING)`,
+			expectedRows: [][]interface{}{{"10:47:51.123456"}},
 		},
 		{
 			name:         "parse time with %I:%M:%S",
@@ -4093,6 +4124,11 @@ SELECT date, EXTRACT(ISOYEAR FROM date), EXTRACT(YEAR FROM date), EXTRACT(MONTH 
 			name:         "format_timestamp with %Ez",
 			query:        `SELECT FORMAT_TIMESTAMP("%Ez", TIMESTAMP "2008-12-25 15:30:12.345678+00")`,
 			expectedRows: [][]interface{}{{"+00:00"}},
+		},
+		{
+			name:         "cast timestamp as string",
+			query:        `SELECT CAST(TIMESTAMP("2022-08-01 06:47:51.123456-07:00") AS STRING);`,
+			expectedRows: [][]interface{}{{"2022-08-01 13:47:51.123456+00"}},
 		},
 		{
 			name:         "parse timestamp with %a %b %e %I:%M:%S %Y",

--- a/query_test.go
+++ b/query_test.go
@@ -1752,6 +1752,11 @@ SELECT * FROM Employees`,
 			},
 		},
 		{
+			name:         "date to json",
+			query:        `SELECT TO_JSON_STRING(DATE(2024, 1, 1))`,
+			expectedRows: [][]interface{}{{`"2024-01-01"`}},
+		},
+		{
 			name: "window rank",
 			query: `
 WITH Employees AS
@@ -2144,6 +2149,14 @@ FROM UNNEST([
 		},
 
 		// array functions
+		{
+			name:  "array formatting",
+			query: `SELECT [0, 1, 1, 2, 3, 5] AS some_numbers;`,
+			expectedRows: [][]interface{}{
+				{[]interface{}{int64(0), int64(1), int64(1), int64(2), int64(3), int64(5)}},
+			},
+		},
+
 		{
 			name:         "make_array",
 			query:        `SELECT a, b FROM UNNEST([STRUCT(DATE(2022, 1, 1) AS a, 1 AS b)])`,
@@ -3661,6 +3674,16 @@ SELECT date, EXTRACT(ISOYEAR FROM date), EXTRACT(YEAR FROM date), EXTRACT(MONTH 
       expectedRows: [][]interface{}{{int64(1302)}},
     },
 		{
+			name:         "date_diff with month",
+			query:        `SELECT DATE_DIFF(DATE '2018-01-01', DATE '2017-10-30', MONTH) AS months_diff`,
+			expectedRows: [][]interface{}{{int64(3)}},
+		},
+		{
+			name:         "date_diff with day",
+			query:        `SELECT DATE_DIFF(DATE '2021-06-06', DATE '2017-11-12', DAY) AS days_diff`,
+			expectedRows: [][]interface{}{{int64(1302)}},
+		},
+		{
 			name:         "date_from_unix_date",
 			query:        `SELECT DATE_FROM_UNIX_DATE(14238) AS date_from_epoch`,
 			expectedRows: [][]interface{}{{"2008-12-25"}},
@@ -3883,6 +3906,16 @@ SELECT date, EXTRACT(ISOYEAR FROM date), EXTRACT(YEAR FROM date), EXTRACT(MONTH 
 			expectedRows: [][]interface{}{{"2008"}},
 		},
 		{
+			name:         "datetime literal",
+			query:        `SELECT DATETIME '2023-01-01 12:01:00'`,
+			expectedRows: [][]interface{}{{"2023-01-01T12:01:00"}},
+		},
+		{
+			name:         "datetime to json",
+			query:        `SELECT TO_JSON_STRING(STRUCT(DATETIME "2006-01-02T15:04:05.999999" AS DT))`,
+			expectedRows: [][]interface{}{{`{"DT":"2006-01-02T15:04:05.999999"}`}},
+		},
+		{
 			name:         "cast datetime as string",
 			query:        `SELECT CAST(DATETIME(TIMESTAMP("2022-08-01 06:47:51.123456-07:00")) AS STRING)`,
 			expectedRows: [][]interface{}{{"2022-08-01 13:47:51.123456"}},
@@ -3974,6 +4007,11 @@ SELECT date, EXTRACT(ISOYEAR FROM date), EXTRACT(YEAR FROM date), EXTRACT(MONTH 
 			expectedRows: [][]interface{}{{"10:47:51.123456"}},
 		},
 		{
+			name:         "time to json string",
+			query:        `SELECT TO_JSON_STRING(TIME("2022-08-01 06:47:51.123456-04:00"))`,
+			expectedRows: [][]interface{}{{`"10:47:51.123456"`}},
+		},
+		{
 			name:         "cast time with timezone as string",
 			query:        `SELECT CAST(TIME("2022-08-01 06:47:51.123456-04:00", "America/Los_Angeles") AS STRING)`,
 			expectedRows: [][]interface{}{{"03:47:51.123456"}},
@@ -4041,6 +4079,17 @@ SELECT date, EXTRACT(ISOYEAR FROM date), EXTRACT(YEAR FROM date), EXTRACT(MONTH 
 			name:         "timestamp from date",
 			query:        `SELECT TIMESTAMP(DATE "2008-12-25")`,
 			expectedRows: [][]interface{}{{createTimestampFormatFromString("2008-12-25 00:00:00+00")}},
+		},
+		{
+			name:         "timestamp to json",
+			query:        `SELECT TO_JSON_STRING(STRUCT(TIMESTAMP "2006-01-02T15:04:05.999999-07" AS TIMESTAMP))`,
+			expectedRows: [][]interface{}{{`{"TIMESTAMP":"2006-01-02T22:04:05.999999Z"}`}},
+		},
+
+		{
+			name:         "timestamp to string",
+			query:        `WITH tmp AS ( SELECT TIMESTAMP "2006-01-02T15:04:05-07" AS TS ) SELECT ts, CAST(ts AS STRING) FROM tmp`,
+			expectedRows: [][]interface{}{{createTimestampFormatFromString(`2006-01-02 22:04:05+00`), `2006-01-02 22:04:05+00`}},
 		},
 		{
 			name:         "timestamp_add",
@@ -4131,6 +4180,11 @@ SELECT date, EXTRACT(ISOYEAR FROM date), EXTRACT(YEAR FROM date), EXTRACT(MONTH 
 			expectedRows: [][]interface{}{{"2022-08-01 13:47:51.123456+00"}},
 		},
 		{
+			name:         "timestamp parses with T value",
+			query:        `SELECT CAST(TIMESTAMP("2022-08-01T06:47:51.123456-07:00") AS STRING);`,
+			expectedRows: [][]interface{}{{"2022-08-01 13:47:51.123456+00"}},
+		},
+		{
 			name:         "parse timestamp with %a %b %e %I:%M:%S %Y",
 			query:        `SELECT PARSE_TIMESTAMP("%a %b %e %I:%M:%S %Y", "Thu Dec 25 07:30:00 2008")`,
 			expectedRows: [][]interface{}{{createTimestampFormatFromString("2008-12-25 07:30:00+00")}},
@@ -4210,6 +4264,7 @@ FROM Input`,
 			query:        `SELECT DATE "2020-09-22" + val FROM UNNEST([INTERVAL 1 DAY,INTERVAL -1 DAY,INTERVAL 2 YEAR,CAST('1-2 3 18:1:55' AS INTERVAL)]) as val`,
 			expectedRows: [][]interface{}{{"2020-09-23T00:00:00"}, {"2020-09-21T00:00:00"}, {"2022-09-22T00:00:00"}, {"2021-11-25T18:01:55"}},
 		},
+
 		{
 			name: "interval from sub operator",
 			query: `
@@ -4273,6 +4328,13 @@ SELECT
 			name:         "cast numeric and bignumeric to string",
 			query:        `SELECT cast(PARSE_NUMERIC("123.456") as STRING), cast(PARSE_BIGNUMERIC("123.456") as STRING)`,
 			expectedRows: [][]interface{}{{"123.456", "123.456"}},
+		},
+
+		// bytes formatting
+		{
+			name:         "bytes_formatting",
+			query:        `SELECT b"abc", CAST(b"abc" AS STRING)`,
+			expectedRows: [][]interface{}{{"YWJj", "abc"}},
 		},
 
 		// security functions


### PR DESCRIPTION
The previous implementation used the same string formatting logic when casting a date/time/datetime/timestamp object to a strings as when it was being encoded as a string. However, BigQuery itself uses different logic in these cases. See screenshots below:

<img width="465" alt="Screen Shot 2023-05-25 at 5 32 45 PM" src="https://github.com/goccy/go-zetasqlite/assets/3762913/c5fce351-b7ee-4b8f-84a4-1503709df37c">

<img width="583" alt="Screen Shot 2023-05-25 at 5 32 05 PM" src="https://github.com/goccy/go-zetasqlite/assets/3762913/073a31dd-8a06-4b4d-8633-0fe98d658196">

This updates the cast method to use these separate formats when casting from a date/time object to a string, but continues to use the prior formats in all other cases.

This tackles the first part of #175. #175 also mentions that the format clause is not supported, which I left out of scope in this PR as it requires writing a new format string parser.