### PR TITLE
Harden string functions when NULL is passed

### DIFF
--- a/internal/function_bind.go
+++ b/internal/function_bind.go
@@ -798,8 +798,11 @@ func bindCollate(args ...Value) (Value, error) {
 }
 
 func bindConcat(args ...Value) (Value, error) {
-	if len(args) < 2 {
+	if len(args) < 1 {
 		return nil, fmt.Errorf("CONCAT: invalid argument num %d", len(args))
+	}
+	if existsNull(args) {
+		return nil, nil
 	}
 	return CONCAT(args...)
 }
@@ -807,6 +810,9 @@ func bindConcat(args ...Value) (Value, error) {
 func bindContainsSubstr(args ...Value) (Value, error) {
 	if args[1] == nil {
 		return nil, fmt.Errorf("CONTAINS_SUBSTR: search literal must be not null")
+	}
+	if existsNull(args) {
+		return nil, nil
 	}
 	search, err := args[1].ToString()
 	if err != nil {
@@ -819,6 +825,9 @@ func bindEndsWith(args ...Value) (Value, error) {
 	if len(args) != 2 {
 		return nil, fmt.Errorf("ENDS_WITH: invalid argument num %d", len(args))
 	}
+	if existsNull(args) {
+		return nil, nil
+	}
 	return ENDS_WITH(args[0], args[1])
 }
 
@@ -826,14 +835,14 @@ func bindFormat(args ...Value) (Value, error) {
 	if len(args) == 0 {
 		return nil, fmt.Errorf("FORMAT: invalid argument num %d", len(args))
 	}
+	if existsNull(args) {
+		return nil, nil
+	}
 	format, err := args[0].ToString()
 	if err != nil {
 		return nil, err
 	}
 	if len(args) > 1 {
-		if args[1] == nil {
-			return nil, nil
-		}
 		return FORMAT(format, args[1:]...)
 	}
 	return FORMAT(format)
@@ -842,6 +851,9 @@ func bindFormat(args ...Value) (Value, error) {
 func bindFromBase32(args ...Value) (Value, error) {
 	if len(args) != 1 {
 		return nil, fmt.Errorf("FROM_BASE32: invalid argument num %d", len(args))
+	}
+	if args[0] == nil {
+		return nil, nil
 	}
 	v, err := args[0].ToString()
 	if err != nil {
@@ -854,6 +866,9 @@ func bindFromBase64(args ...Value) (Value, error) {
 	if len(args) != 1 {
 		return nil, fmt.Errorf("FROM_BASE64: invalid argument num %d", len(args))
 	}
+	if args[0] == nil {
+		return nil, nil
+	}
 	v, err := args[0].ToString()
 	if err != nil {
 		return nil, err
@@ -864,6 +879,9 @@ func bindFromBase64(args ...Value) (Value, error) {
 func bindFromHex(args ...Value) (Value, error) {
 	if len(args) != 1 {
 		return nil, fmt.Errorf("FROM_HEX: invalid argument num %d", len(args))
+	}
+	if args[0] == nil {
+		return nil, nil
 	}
 	v, err := args[0].ToString()
 	if err != nil {
@@ -876,14 +894,11 @@ func bindInitcap(args ...Value) (Value, error) {
 	if len(args) != 1 && len(args) != 2 {
 		return nil, fmt.Errorf("INITCAP: invalid argument num %d", len(args))
 	}
-	if args[0] == nil {
+	if existsNull(args) {
 		return nil, nil
 	}
 	var delimiters []rune
 	if len(args) == 2 {
-		if args[1] == nil {
-			return nil, nil
-		}
 		v, err := args[1].ToString()
 		if err != nil {
 			return nil, err
@@ -904,10 +919,7 @@ func bindInstr(args ...Value) (Value, error) {
 	if len(args) != 2 && len(args) != 3 && len(args) != 4 {
 		return nil, fmt.Errorf("INSTR: invalid argument num %d", len(args))
 	}
-	if args[0] == nil {
-		return nil, nil
-	}
-	if args[1] == nil {
+	if existsNull(args) {
 		return nil, nil
 	}
 	var (
@@ -935,6 +947,9 @@ func bindLeft(args ...Value) (Value, error) {
 	if len(args) != 2 {
 		return nil, fmt.Errorf("LEFT: invalid argument num %d", len(args))
 	}
+	if existsNull(args) {
+		return nil, nil
+	}
 	length, err := args[1].ToInt64()
 	if err != nil {
 		return nil, err
@@ -947,7 +962,7 @@ func bindLength(args ...Value) (Value, error) {
 		return nil, fmt.Errorf("LENGTH: invalid argument num %d", len(args))
 	}
 	if args[0] == nil {
-		return IntValue(0), nil
+		return nil, nil
 	}
 	return LENGTH(args[0])
 }
@@ -955,6 +970,9 @@ func bindLength(args ...Value) (Value, error) {
 func bindLpad(args ...Value) (Value, error) {
 	if len(args) != 2 && len(args) != 3 {
 		return nil, fmt.Errorf("LPAD: invalid argument num %d", len(args))
+	}
+	if existsNull(args) {
+		return nil, nil
 	}
 	var pattern Value
 	if len(args) == 3 {
@@ -971,12 +989,18 @@ func bindLower(args ...Value) (Value, error) {
 	if len(args) != 1 {
 		return nil, fmt.Errorf("LOWER: invalid argument num %d", len(args))
 	}
+	if existsNull(args) {
+		return nil, nil
+	}
 	return LOWER(args[0])
 }
 
 func bindLtrim(args ...Value) (Value, error) {
 	if len(args) != 1 && len(args) != 2 {
 		return nil, fmt.Errorf("LTRIM: invalid argument num %d", len(args))
+	}
+	if existsNull(args) {
+		return nil, nil
 	}
 	cutset := " "
 	if len(args) == 2 {
@@ -992,6 +1016,9 @@ func bindLtrim(args ...Value) (Value, error) {
 func bindNormalize(args ...Value) (Value, error) {
 	if len(args) != 1 && len(args) != 2 {
 		return nil, fmt.Errorf("NORMALIZE: invalid argument num %d", len(args))
+	}
+	if existsNull(args) {
+		return nil, nil
 	}
 	mode := "NFC"
 	if len(args) == 2 {
@@ -1011,6 +1038,9 @@ func bindNormalize(args ...Value) (Value, error) {
 func bindNormalizeAndCasefold(args ...Value) (Value, error) {
 	if len(args) != 1 && len(args) != 2 {
 		return nil, fmt.Errorf("NORMALIZE_AND_CASEFOLD: invalid argument num %d", len(args))
+	}
+	if existsNull(args) {
+		return nil, nil
 	}
 	mode := "NFC"
 	if len(args) == 2 {
@@ -1043,6 +1073,9 @@ func bindRegexpContains(args ...Value) (Value, error) {
 }
 
 func bindRegexpExtract(args ...Value) (Value, error) {
+	if existsNull(args) {
+		return nil, nil
+	}
 	regexp, err := args[1].ToString()
 	if err != nil {
 		return nil, err
@@ -1067,6 +1100,9 @@ func bindRegexpExtract(args ...Value) (Value, error) {
 }
 
 func bindRegexpExtractAll(args ...Value) (Value, error) {
+	if existsNull(args) {
+		return nil, nil
+	}
 	regexp, err := args[1].ToString()
 	if err != nil {
 		return nil, err
@@ -1075,6 +1111,9 @@ func bindRegexpExtractAll(args ...Value) (Value, error) {
 }
 
 func bindRegexpInstr(args ...Value) (Value, error) {
+	if existsNull(args) {
+		return nil, nil
+	}
 	var (
 		pos           int64 = 1
 		occurrence    int64 = 1
@@ -1105,6 +1144,9 @@ func bindRegexpInstr(args ...Value) (Value, error) {
 }
 
 func bindRegexpReplace(args ...Value) (Value, error) {
+	if existsNull(args) {
+		return nil, nil
+	}
 	return REGEXP_REPLACE(args[0], args[1], args[2])
 }
 
@@ -1198,7 +1240,7 @@ func bindSoundex(args ...Value) (Value, error) {
 
 func bindSplit(args ...Value) (Value, error) {
 	if existsNull(args) {
-		return nil, nil
+		return &ArrayValue{}, nil
 	}
 	var delim Value
 	if len(args) > 1 {
@@ -1211,6 +1253,9 @@ func bindStartsWith(args ...Value) (Value, error) {
 	if len(args) != 2 {
 		return nil, fmt.Errorf("STARTS_WITH: invalid argument num %d", len(args))
 	}
+	if existsNull(args) {
+		return nil, nil
+	}
 	return STARTS_WITH(args[0], args[1])
 }
 
@@ -1218,12 +1263,18 @@ func bindStrpos(args ...Value) (Value, error) {
 	if len(args) != 2 {
 		return nil, fmt.Errorf("STRPOS: invalid argument num %d", len(args))
 	}
+	if existsNull(args) {
+		return nil, nil
+	}
 	return STRPOS(args[0], args[1])
 }
 
 func bindSubstr(args ...Value) (Value, error) {
 	if len(args) != 2 && len(args) != 3 {
 		return nil, fmt.Errorf("SUBSTR: invalid argument num %d", len(args))
+	}
+	if existsNull(args) {
+		return nil, nil
 	}
 	pos, err := args[1].ToInt64()
 	if err != nil {
@@ -1244,6 +1295,9 @@ func bindToBase32(args ...Value) (Value, error) {
 	if len(args) != 1 {
 		return nil, fmt.Errorf("TO_BASE32: invalid argument num %d", len(args))
 	}
+	if existsNull(args) {
+		return nil, nil
+	}
 	b, err := args[0].ToBytes()
 	if err != nil {
 		return nil, err
@@ -1254,6 +1308,9 @@ func bindToBase32(args ...Value) (Value, error) {
 func bindToBase64(args ...Value) (Value, error) {
 	if len(args) != 1 {
 		return nil, fmt.Errorf("TO_BASE64: invalid argument num %d", len(args))
+	}
+	if existsNull(args) {
+		return nil, nil
 	}
 	b, err := args[0].ToBytes()
 	if err != nil {
@@ -1266,12 +1323,18 @@ func bindToCodePoints(args ...Value) (Value, error) {
 	if len(args) != 1 {
 		return nil, fmt.Errorf("TO_CODE_POINTS: invalid argument num %d", len(args))
 	}
+	if args[0] == nil {
+		return &ArrayValue{}, nil
+	}
 	return TO_CODE_POINTS(args[0])
 }
 
 func bindToHex(args ...Value) (Value, error) {
 	if len(args) != 1 {
 		return nil, fmt.Errorf("TO_HEX: invalid argument num %d", len(args))
+	}
+	if existsNull(args) {
+		return nil, nil
 	}
 	b, err := args[0].ToBytes()
 	if err != nil {
@@ -1284,12 +1347,18 @@ func bindTranslate(args ...Value) (Value, error) {
 	if len(args) != 3 {
 		return nil, fmt.Errorf("TRANSLATE: invalid argument num %d", len(args))
 	}
+	if existsNull(args) {
+		return nil, nil
+	}
 	return TRANSLATE(args[0], args[1], args[2])
 }
 
 func bindTrim(args ...Value) (Value, error) {
 	if len(args) != 1 && len(args) != 2 {
 		return nil, fmt.Errorf("TRIM: invalid argument num %d", len(args))
+	}
+	if existsNull(args) {
+		return nil, nil
 	}
 	if len(args) == 2 {
 		return TRIM(args[0], args[1])
@@ -1459,6 +1528,9 @@ func bindParseJson(args ...Value) (Value, error) {
 func bindToJson(args ...Value) (Value, error) {
 	if len(args) != 1 && len(args) != 2 {
 		return nil, fmt.Errorf("TO_JSON: invalid argument num %d", len(args))
+	}
+	if existsNull(args) {
+		return nil, nil
 	}
 	var stringifyWideNumbers bool
 	if len(args) == 2 {

--- a/internal/function_string.go
+++ b/internal/function_string.go
@@ -415,6 +415,9 @@ func LPAD(originalValue Value, returnLength int64, pattern Value) (Value, error)
 }
 
 func LOWER(v Value) (Value, error) {
+	if v == nil {
+		return nil, nil
+	}
 	switch v.(type) {
 	case StringValue:
 		s, err := v.ToString()
@@ -697,7 +700,7 @@ func REGEXP_REPLACE(value, exprValue, replacementValue Value) (Value, error) {
 		}
 		return BytesValue(re.ReplaceAll(v, []byte(normalizeReplacement(string(replacement))))), nil
 	}
-	return nil, fmt.Errorf("REGEXP_REPLACE: value must be STRING or BYTES")
+	return nil, fmt.Errorf("REGEXP_REPLACE: value must be STRING or BYTES, %s", value)
 }
 
 func REPLACE(originalValue, fromValue, toValue Value) (Value, error) {

--- a/query_test.go
+++ b/query_test.go
@@ -841,7 +841,6 @@ SELECT ARRAY_CONCAT_AGG(x) AS array_concat_agg FROM (
 			name:  "string_agg with window",
 			query: `SELECT fruit, STRING_AGG(fruit, " & ") OVER (ORDER BY LENGTH(fruit)) FROM UNNEST(["apple", "pear", "banana", "pear"]) AS fruit`,
 			expectedRows: [][]interface{}{
-				{nil, nil},
 				{"pear", "pear & pear"},
 				{"pear", "pear & pear"},
 				{"apple", "pear & pear & apple"},


### PR DESCRIPTION
We noticed that when using some string functions, like `LEFT` or `REGEXP_REPLACE`, if one of the values passed to the function was NULL we would receive an error like:

```
zetasqlite_collate: LEFT: value type is must be STRING or BYTES type
```

This updates the string functions to more consistently check for NULL parameters and return the correct value, either NULL or an empty array, depending on whether the function returns a single value or an array.