### PR TITLE
Support precision in ROUND

### DIFF
--- a/internal/function_bind.go
+++ b/internal/function_bind.go
@@ -1679,10 +1679,32 @@ func bindMod(args ...Value) (Value, error) {
 }
 
 func bindRound(args ...Value) (Value, error) {
+	if len(args) != 1 && len(args) != 2 && len(args) != 3 {
+		return nil, fmt.Errorf("ROUND: invalid argument num %d", len(args))
+	}
+	var precision = 0
+	var roundMode = "ROUND_HALF_AWAY_FROM_ZERO"
+	if len(args) > 1 {
+		precision, err := args[1].ToInt64()
+		if err != nil {
+			return nil, err
+		}
+	}
+	if len(args) == 3 {
+		mode, err := args[2].ToString()
+		if err != nil {
+			return nil, err
+		}
+		if mode != "ROUND_HALF_AWAY_FROM_ZERO" && mode != "ROUND_HALF_EVEN" {
+			return nil, fmt.Errorf("ROUND: invalid rounding_mode")
+		}
+		roundMode = mode
+	}
 	if existsNull(args) {
 		return nil, nil
 	}
-	return ROUND(args[0])
+
+	return ROUND(args[0], precision, roundMode)
 }
 
 func bindTrunc(args ...Value) (Value, error) {

--- a/internal/function_bind.go
+++ b/internal/function_bind.go
@@ -1679,32 +1679,23 @@ func bindMod(args ...Value) (Value, error) {
 }
 
 func bindRound(args ...Value) (Value, error) {
-	if len(args) != 1 && len(args) != 2 && len(args) != 3 {
+	if len(args) != 1 && len(args) != 2 {
 		return nil, fmt.Errorf("ROUND: invalid argument num %d", len(args))
 	}
-	var precision = 0
-	var roundMode = "ROUND_HALF_AWAY_FROM_ZERO"
-	if len(args) > 1 {
-		precision, err := args[1].ToInt64()
+	var precision int = 0
+	if len(args) == 2 {
+		i64, err := args[1].ToInt64()
 		if err != nil {
 			return nil, err
 		}
+		precision = int(i64)
 	}
-	if len(args) == 3 {
-		mode, err := args[2].ToString()
-		if err != nil {
-			return nil, err
-		}
-		if mode != "ROUND_HALF_AWAY_FROM_ZERO" && mode != "ROUND_HALF_EVEN" {
-			return nil, fmt.Errorf("ROUND: invalid rounding_mode")
-		}
-		roundMode = mode
-	}
+
 	if existsNull(args) {
 		return nil, nil
 	}
 
-	return ROUND(args[0], precision, roundMode)
+	return ROUND(args[0], precision)
 }
 
 func bindTrunc(args ...Value) (Value, error) {

--- a/internal/function_math.go
+++ b/internal/function_math.go
@@ -5,6 +5,8 @@ import (
 	"math"
 	"math/rand"
 	"time"
+
+	"gonum.org/v1/gonum/floats/scalar"
 )
 
 func ABS(a Value) (Value, error) {
@@ -260,12 +262,15 @@ func MOD(x, y Value) (Value, error) {
 	return FloatValue(math.Mod(xv, yv)), nil
 }
 
-func ROUND(x Value) (Value, error) {
+func ROUND(x Value, precision int, roundMode string) (Value, error) {
 	xv, err := x.ToFloat64()
 	if err != nil {
 		return nil, err
 	}
-	return FloatValue(math.Round(xv)), nil
+	if roundMode == "ROUND_HALF_EVEN" {
+		return FloatValue(scalar.RoundEven(xv, precision)), nil
+	}
+	return FloatValue(scalar.Round(xv, precision)), nil
 }
 
 func TRUNC(x Value) (Value, error) {

--- a/internal/function_math.go
+++ b/internal/function_math.go
@@ -262,13 +262,10 @@ func MOD(x, y Value) (Value, error) {
 	return FloatValue(math.Mod(xv, yv)), nil
 }
 
-func ROUND(x Value, precision int, roundMode string) (Value, error) {
+func ROUND(x Value, precision int) (Value, error) {
 	xv, err := x.ToFloat64()
 	if err != nil {
 		return nil, err
-	}
-	if roundMode == "ROUND_HALF_EVEN" {
-		return FloatValue(scalar.RoundEven(xv, precision)), nil
 	}
 	return FloatValue(scalar.Round(xv, precision)), nil
 }

--- a/query_test.go
+++ b/query_test.go
@@ -469,6 +469,16 @@ FROM UNNEST([1, 2, 3, 4]) AS val`,
 			expectedRows: [][]interface{}{{int64(10)}},
 		},
 		{
+			name:         "rounding",
+			query:        `SELECT ROUND(2.0), ROUND(2.3), ROUND(2.8), ROUND(2.5), ROUND(-2.3), ROUND(-2.8), ROUND(-2.5)`,
+			expectedRows: [][]interface{}{{float64(2.0), float64(2.0), float64(3.0), float64(3.0), float64(-2.0), float64(-3.0), float64(-3.0)}},
+		},
+		{
+			name:         "rounding precision",
+			query:        `SELECT ROUND(123.7, -1), ROUND(1.235, 2)`,
+			expectedRows: [][]interface{}{{float64(120.0), float64(1.24)}},
+		},
+		{
 			name: "with clause",
 			query: `
 WITH sub1 AS (SELECT ["a", "b"]),


### PR DESCRIPTION
Support the `precision` parameter in the `ROUND` function.

Doesn't support `rounding_mode` as the analyzer doesn't support the signature `(NUMERIC, INT64, STRING)`.