### PR TITLE
Fix issue with passing parameters to a multiple statements SQL query

### DIFF
--- a/internal/analyzer.go
+++ b/internal/analyzer.go
@@ -208,7 +208,9 @@ func (a *Analyzer) Analyze(ctx context.Context, conn *Conn, query string, args [
 			if err != nil {
 				return nil, err
 			}
-			args = args[:len(action.Args())]
+			if mode == zetasql.ParameterPositional {
+				args = args[len(action.Args()):]
+			}
 			return action, nil
 		})
 	}

--- a/query_test.go
+++ b/query_test.go
@@ -4992,6 +4992,65 @@ FROM (
 				{nil},
 			},
 		},
+
+		{
+			name: "single statement with named params",
+			query: `
+SELECT @a + @b;
+`,
+			args: []interface{}{
+				sql.NamedArg{Name: "a", Value: 1},
+				sql.NamedArg{Name: "b", Value: 2},
+			},
+			expectedRows: [][]interface{}{{int64(3)}},
+		},
+		{
+			name: "not enough named params given",
+			query: `
+SELECT @a + @b;
+`,
+			args:        []interface{}{sql.NamedArg{Name: "a", Value: 1}},
+			expectedErr: "not enough query arguments",
+		},
+		{
+			name: "multiple statements with named params",
+			query: `
+CREATE TEMP TABLE t1 AS SELECT @a c1;
+SELECT c1 * @b * @c FROM t1;
+`,
+			args: []interface{}{
+				sql.NamedArg{Name: "a", Value: 1},
+				sql.NamedArg{Name: "b", Value: 2},
+				sql.NamedArg{Name: "c", Value: 3},
+			},
+			expectedRows: [][]interface{}{{int64(6)}},
+		},
+
+		{
+			name: "single statement with positional params",
+			query: `
+SELECT ? + ?;
+`,
+			args:         []interface{}{int64(1), int64(2)},
+			expectedRows: [][]interface{}{{int64(3)}},
+		},
+		{
+			name: "not enough positional params given",
+			query: `
+SELECT ? + ?;
+`,
+			args:        []interface{}{int64(1)},
+			expectedErr: "not enough query arguments",
+		},
+		{
+			name: "multiple statements with positional params",
+			query: `
+CREATE TEMP TABLE t1 AS SELECT ? c1;
+SELECT c1 * ? * ? FROM t1;
+`,
+			args:         []interface{}{int64(1), int64(2), int64(3)},
+			expectedRows: [][]interface{}{{int64(6)}},
+		},
 	} {
 		test := test
 		t.Run(test.name, func(t *testing.T) {


### PR DESCRIPTION
## Summary of problem:

An error `not enough query arguments` occurs when passing parameters to and executing SQL statements containing multiple statements.

This issue seems to occur under the following conditions:

* The SQL contains multiple statements.
* The preceding statement contains fewer parameters than the succeeding statements.

An example SQL that causes an error is shown below:

```sql
CREATE TEMP TABLE t1 AS SELECT @a c1;
SELECT c1 * @b * @c FROM t1;
```

In this example, the first SELECT statement has only one parameter, while the following SELECT statement have two. 
This query causes the error `not enough query arguments`, even though passing sufficient numbers of arguments.

## (possible) cause

This problem seems to arise because args are trimmed when creating actionFunc in `Analyze` function of `analyzer.go` .

* In the case of `ParameterNamed`
  * it seems inappropriate to simply trim in order because it is possible to delete parameters that are necessary in subsequent statements.
* In the case of `ParameterPositional`
  * It is necessary to trim in order, but even in this case, the direction of extraction seems to be reversed. It's currently `args[:len(action.Args())]`, extracting the number of arguments for that statement from the beginning. Therefore, if parameters are not used in a statement, args becomes an empty array. (because it extracts 0 args and assign it to `args`) When the subsequent statements uses parameters, this results in the error `not enough query arguments`.

## Changes made in this PR:

The handling of args was modified according to ParameterMode:

* For ParameterNamed, no changes to be made.
* For ParameterPositional, the number of args used in that statement is removed from the beginning.

I would appreciate if you could look into it. Thank you