### PR TITLE
Handle JSON-Null values in JSON functions

### DIFF
--- a/internal/function_json.go
+++ b/internal/function_json.go
@@ -160,7 +160,7 @@ func JSON_EXTRACT_STRING_ARRAY(v, path string) (Value, error) {
 	}
 	value := values[0]
 	rv := reflect.ValueOf(value)
-	if rv.Type().Kind() != reflect.Slice {
+	if !rv.IsValid() || rv.Type().Kind() != reflect.Slice {
 		return nil, nil
 	}
 	ret := &ArrayValue{}
@@ -223,6 +223,9 @@ func JSON_VALUE(v, path string) (Value, error) {
 		return nil, nil
 	}
 	value := values[0]
+	if !reflect.ValueOf(value).IsValid() {
+		return nil, nil
+	}
 	switch reflect.ValueOf(value).Type().Kind() {
 	case reflect.Map, reflect.Slice:
 		return nil, nil
@@ -284,7 +287,7 @@ func JSON_VALUE_ARRAY(v, path string) (Value, error) {
 	}
 	value := values[0]
 	rv := reflect.ValueOf(value)
-	if rv.Type().Kind() != reflect.Slice {
+	if !rv.IsValid() || rv.Type().Kind() != reflect.Slice {
 		return nil, nil
 	}
 	ret := &ArrayValue{}

--- a/query_test.go
+++ b/query_test.go
@@ -4456,6 +4456,11 @@ SELECT
 			expectedRows: [][]interface{}{{"world"}},
 		},
 		{
+			name:         "json_value with null",
+			query:        `SELECT JSON_VALUE(JSON 'null'), JSON_VALUE(NULL), JSON_VALUE(JSON '{}', '$.does_not_exist')`,
+			expectedRows: [][]interface{}{{nil, nil, nil}},
+		},
+		{
 			name:  "json_extract_array",
 			query: `SELECT JSON_EXTRACT_ARRAY(JSON '{"fruits":["apples","oranges","grapes"]}','$.fruits')`,
 			expectedRows: [][]interface{}{
@@ -4497,8 +4502,8 @@ SELECT
 		},
 		{
 			name:         "json_extract_array with null",
-			query:        `SELECT JSON_EXTRACT_ARRAY('{"a":"foo"}','$.a'), JSON_EXTRACT_ARRAY('{"a":"foo"}','$.b')`,
-			expectedRows: [][]interface{}{{nil, nil}},
+			query:        `SELECT JSON_EXTRACT_ARRAY('{"a":"foo"}','$.a'), JSON_EXTRACT_ARRAY('{"a":"foo"}','$.b'), JSON_EXTRACT_ARRAY(JSON 'null', '$')`,
+			expectedRows: [][]interface{}{{nil, nil, nil}},
 		},
 		{
 			name:         "json_extract_array with empty array",
@@ -4547,8 +4552,8 @@ SELECT
 		},
 		{
 			name:         "json_query_array with null",
-			query:        `SELECT JSON_QUERY_ARRAY('{"a":"foo"}','$.a'), JSON_EXTRACT_ARRAY('{"a":"foo"}','$.b')`,
-			expectedRows: [][]interface{}{{nil, nil}},
+			query:        `SELECT JSON_QUERY_ARRAY('{"a":"foo"}','$.a'), JSON_QUERY_ARRAY('{"a":"foo"}','$.b'), JSON_QUERY_ARRAY(JSON 'null', '$')`,
+			expectedRows: [][]interface{}{{nil, nil, nil}},
 		},
 		{
 			name:         "json_query_array with empty array",
@@ -4592,8 +4597,9 @@ SELECT
   JSON_EXTRACT_STRING_ARRAY('{"a":["foo","bar","baz"]}','$.b'),
   JSON_EXTRACT_STRING_ARRAY('{"a":"foo"}','$'),
   JSON_EXTRACT_STRING_ARRAY('{"a":[{"b":"foo","c":1},{"b":"bar","c":2}],"d":"baz"}','$.a'),
-  JSON_EXTRACT_STRING_ARRAY('{"a":[10, {"b": 20}]','$.a')`,
-			expectedRows: [][]interface{}{{nil, nil, nil, nil, nil, nil}},
+  JSON_EXTRACT_STRING_ARRAY('{"a":[10, {"b": 20}]','$.a'),
+  JSON_EXTRACT_STRING_ARRAY(JSON 'null', '$')`,
+			expectedRows: [][]interface{}{{nil, nil, nil, nil, nil, nil, nil}},
 		},
 		{
 			name:         "json_extract_string_array with empty array",
@@ -4637,8 +4643,9 @@ SELECT
   JSON_VALUE_ARRAY('{"a":["foo","bar","baz"]}','$.b'),
   JSON_VALUE_ARRAY('{"a":"foo"}','$'),
   JSON_VALUE_ARRAY('{"a":[{"b":"foo","c":1},{"b":"bar","c":2}],"d":"baz"}','$.a'),
-  JSON_VALUE_ARRAY('{"a":[10, {"b": 20}]','$.a')`,
-			expectedRows: [][]interface{}{{nil, nil, nil, nil, nil, nil}},
+  JSON_VALUE_ARRAY('{"a":[10, {"b": 20}]','$.a'),
+  JSON_VALUE_ARRAY(JSON 'null', '$')`,
+			expectedRows: [][]interface{}{{nil, nil, nil, nil, nil, nil, nil}},
 		},
 		{
 			name:         "json_value_array with empty array",


### PR DESCRIPTION
This fixes a small issues with null-values in JSON. JSON functions like JSON_VALUE or JSON_QUERY have been panicking so far when they encountered a JSON null value as its input.

Example:
`SELECT JSON_VALUE(JSON 'null')` has been panicking and is now correctly returning `NULL`/`nil`.

I also adjusted the tests and hope I didn't miss anything.

Fixes: #121