### PR TITLE
DATE_DIFF fix for days and months

### DIFF
--- a/internal/function_date.go
+++ b/internal/function_date.go
@@ -86,13 +86,13 @@ func DATE_SUB(t time.Time, v int64, part string) (Value, error) {
 func DATE_DIFF(a, b time.Time, part string) (Value, error) {
 	switch part {
 	case "DAY":
-		return IntValue(a.Day() - b.Day()), nil
+		return IntValue(int64(a.Sub(b).Hours() / 24)), nil
 	case "WEEK":
 		_, aWeek := a.ISOWeek()
 		_, bWeek := b.ISOWeek()
 		return IntValue(aWeek - bWeek), nil
 	case "MONTH":
-		return IntValue(a.Month() - b.Month()), nil
+		return IntValue((a.Year() * 12 + int(a.Month())) - (b.Year() * 12 + int(b.Month()))), nil
 	case "YEAR":
 		return IntValue(a.Year() - b.Year()), nil
 	}

--- a/query_test.go
+++ b/query_test.go
@@ -3618,6 +3618,16 @@ SELECT date, EXTRACT(ISOYEAR FROM date), EXTRACT(YEAR FROM date), EXTRACT(MONTH 
 			query:        `SELECT DATE_DIFF(DATE '2017-10-17', DATE '2017-10-12', WEEK) AS weeks_diff`,
 			expectedRows: [][]interface{}{{int64(1)}},
 		},
+    {
+      name:         "date_diff with month",
+      query:        `SELECT DATE_DIFF(DATE '2018-01-01', DATE '2017-10-30', MONTH) AS months_diff`,
+      expectedRows: [][]interface{}{{int64(3)}},
+    },
+    {
+      name:         "date_diff with day",
+      query:        `SELECT DATE_DIFF(DATE '2021-06-06', DATE '2017-11-12', DAY) AS days_diff`,
+      expectedRows: [][]interface{}{{int64(1302)}},
+    },
 		{
 			name:         "date_from_unix_date",
 			query:        `SELECT DATE_FROM_UNIX_DATE(14238) AS date_from_epoch`,


### PR DESCRIPTION
`DATE_DIFF` function produced incorrect results for days and months if dates were from different years