### PR TITLE
Update `formatPatternMap` to correctly interpret `%u`

### DIFF
--- a/internal/function_time_parser.go
+++ b/internal/function_time_parser.go
@@ -323,8 +323,8 @@ var formatPatternMap = map[rune]*FormatTimeInfo{
 		AvailableTypes: []TimeFormatType{
 			FormatTypeDate, FormatTypeDatetime, FormatTypeTimestamp,
 		},
-		Parse:  weekNumberParser,
-		Format: weekNumberFormatter,
+		Parse:  weekOfDayParser,
+		Format: weekOfDayNumberFormatter,
 	},
 	'V': &FormatTimeInfo{
 		AvailableTypes: []TimeFormatType{
@@ -414,6 +414,10 @@ func weekOfDayParser(text []rune, t *time.Time) (int, error) {
 
 func weekOfDayFormatter(t *time.Time) ([]rune, error) {
 	return []rune(dayOfWeeks[int(t.Weekday())]), nil
+}
+
+func weekOfDayNumberFormatter(t *time.Time) ([]rune, error) {
+	return []rune(fmt.Sprint(int(t.Weekday())))
 }
 
 func shortWeekOfDayParser(text []rune, t *time.Time) (int, error) {

--- a/query_test.go
+++ b/query_test.go
@@ -4028,6 +4028,11 @@ SELECT date, EXTRACT(ISOYEAR FROM date), EXTRACT(YEAR FROM date), EXTRACT(MONTH 
 			expectedRows: [][]interface{}{{"Dec 2008"}},
 		},
 		{
+			name:         "format_timestamp with %u",
+			query:        `SELECT FORMAT_TIMESTAMP("%u", TIMESTAMP "2008-12-25 15:30:00+00")`,
+			expectedRows: [][]interface{}{{"4"}},
+		},
+		{
 			name:         "format_timestamp with %Y-%m-%d %H:%M:%S",
 			query:        `SELECT FORMAT_TIMESTAMP("%Y-%m-%d %H:%M:%S", TIMESTAMP "2008-12-25 15:30:21+00", "Asia/Tokyo")`,
 			expectedRows: [][]interface{}{{"2008-12-26 00:30:21"}},


### PR DESCRIPTION
Solves https://github.com/goccy/go-zetasqlite/issues/125

### Summary of problem:

When using something like `FORMAT_TIMESTAMP('%u', sale_happened_at)` it currently returns the week number of the current year (e.g. `43`). 

According to the [BigQuery docs](https://cloud.google.com/bigquery/docs/reference/standard-sql/format-elements#format_elements_date_time) this should return the number of the week day instead (starting at `0` for `Sunday`).

### (possible) cause

It looks like this is simply calling the wrong function.

### Changes made in this PR:
I created a new function to return the number and added a test.

Thank you for considering this merge!