### PR TITLE
[Testing] Use UTC timezone in `query_test.go`

### DIFF
--- a/query_test.go
+++ b/query_test.go
@@ -5,6 +5,7 @@ import (
 	"database/sql"
 	"fmt"
 	"math"
+	"os"
 	"reflect"
 	"testing"
 	"time"
@@ -14,6 +15,7 @@ import (
 )
 
 func TestQuery(t *testing.T) {
+	os.Setenv("TZ", "UTC")
 	now := time.Now()
 	ctx := context.Background()
 	ctx = zetasqlite.WithCurrentTime(ctx, now)
@@ -3650,16 +3652,16 @@ SELECT date, EXTRACT(ISOYEAR FROM date), EXTRACT(YEAR FROM date), EXTRACT(MONTH 
 			query:        `SELECT DATE_DIFF(DATE '2017-10-17', DATE '2017-10-12', WEEK) AS weeks_diff`,
 			expectedRows: [][]interface{}{{int64(1)}},
 		},
-    {
-      name:         "date_diff with month",
-      query:        `SELECT DATE_DIFF(DATE '2018-01-01', DATE '2017-10-30', MONTH) AS months_diff`,
-      expectedRows: [][]interface{}{{int64(3)}},
-    },
-    {
-      name:         "date_diff with day",
-      query:        `SELECT DATE_DIFF(DATE '2021-06-06', DATE '2017-11-12', DAY) AS days_diff`,
-      expectedRows: [][]interface{}{{int64(1302)}},
-    },
+		{
+			name:         "date_diff with month",
+			query:        `SELECT DATE_DIFF(DATE '2018-01-01', DATE '2017-10-30', MONTH) AS months_diff`,
+			expectedRows: [][]interface{}{{int64(3)}},
+		},
+		{
+			name:         "date_diff with day",
+			query:        `SELECT DATE_DIFF(DATE '2021-06-06', DATE '2017-11-12', DAY) AS days_diff`,
+			expectedRows: [][]interface{}{{int64(1302)}},
+		},
 		{
 			name:         "date_from_unix_date",
 			query:        `SELECT DATE_FROM_UNIX_DATE(14238) AS date_from_epoch`,
@@ -5159,6 +5161,7 @@ SELECT c1 * ? * ? FROM t1;
 			}
 		})
 	}
+	os.Unsetenv("TZ")
 }
 
 func createTimestampFormatFromTime(t time.Time) string {


### PR DESCRIPTION
Hi @goccy, its nice to meet you. The team @Recidiviz is grateful for your work on this project.

I will be spending time this quarter contributing to the `goccy/bigquery-emulator` and `goccy/go-zetasqlite` repositories. I'll also be taking over the open work by @colincadams in #111 and #112.

This is a small change to get the `query_test.go` tests to pass locally when running in a non-UTC timezone.