### PR TITLE
[Date] Implement `%y` year without century parser / formatter; respect digits that are below maximum format length

### DIFF
--- a/internal/func_time_parser_test.go
+++ b/internal/func_time_parser_test.go
@@ -1,0 +1,93 @@
+package internal
+
+import "testing"
+
+func TestQuery(t *testing.T) {
+	for _, test := range []struct {
+		name             string
+		text             []rune
+		minValue         int64
+		maxValue         int64
+		expectedProgress int
+		expectedResult   int
+		expectedErr      string
+	}{
+		{
+			name:             "single digit but multiple allowed; non-digit character terminates",
+			text:             []rune{'2', '/'},
+			minValue:         1,
+			maxValue:         12,
+			expectedResult:   2,
+			expectedProgress: 1,
+		},
+		{
+			name:             "multiple digits; non-digit character terminates",
+			text:             []rune{'1', '2', '/'},
+			minValue:         1,
+			maxValue:         12,
+			expectedResult:   12,
+			expectedProgress: 2,
+		},
+		{
+			name:             "leading zero digit but multiple allowed; non-digit character terminates",
+			text:             []rune{'0', '2', '/'},
+			minValue:         1,
+			maxValue:         12,
+			expectedResult:   2,
+			expectedProgress: 2,
+		},
+
+		{
+			name:             "leading zero digit but multiple allowed; non-digit character terminates",
+			text:             []rune{'0', '0', '2', '/'},
+			minValue:         1,
+			maxValue:         9999,
+			expectedResult:   2,
+			expectedProgress: 3,
+		},
+		{
+			name:        "multiple digits but exceeds limit; non-digit character terminates",
+			text:        []rune{'2', '2', '/'},
+			minValue:    1,
+			maxValue:    12,
+			expectedErr: "part [22] is greater than maximum value [12]",
+		},
+		{
+			name:        "multiple digits but lower than start bound; non-digit character terminates",
+			text:        []rune{'0', '0', '/'},
+			minValue:    1,
+			maxValue:    12,
+			expectedErr: "part [0] is less than minimum value [1] ",
+		},
+		{
+			name:             "multiple digits but lower than start bound; non-digit character terminates",
+			text:             []rune{'4', '-'},
+			minValue:         1,
+			maxValue:         12,
+			expectedResult:   4,
+			expectedProgress: 1,
+		},
+	} {
+
+		t.Run(test.name, func(t *testing.T) {
+			progress, result, err := parseDigitRespectingOptionalPlaces(test.text, test.minValue, test.maxValue)
+			if err != nil {
+				if test.expectedErr != err.Error() {
+					t.Fatalf("unexpected error message: expected [%s] but got [%s]", test.expectedErr, err.Error())
+				} else {
+					// expected error occurred, consider test successful
+					return
+				}
+			}
+
+			if progress != test.expectedProgress {
+				t.Fatalf("unexpected progress: expected [%d] but got [%d]", test.expectedProgress, progress)
+			}
+
+			if result != int64(test.expectedResult) {
+				t.Fatalf("unexpected result: expected [%d] but got [%d]", test.expectedResult, result)
+			}
+
+		})
+	}
+}

--- a/internal/func_time_parser_test.go
+++ b/internal/func_time_parser_test.go
@@ -2,7 +2,7 @@ package internal
 
 import "testing"
 
-func TestQuery(t *testing.T) {
+func TestTimeParser(t *testing.T) {
 	for _, test := range []struct {
 		name             string
 		text             []rune
@@ -57,7 +57,7 @@ func TestQuery(t *testing.T) {
 			text:        []rune{'0', '0', '/'},
 			minValue:    1,
 			maxValue:    12,
-			expectedErr: "part [0] is less than minimum value [1] ",
+			expectedErr: "part [0] is less than minimum value [1]",
 		},
 		{
 			name:             "multiple digits but lower than start bound; non-digit character terminates",

--- a/internal/function_time_parser.go
+++ b/internal/function_time_parser.go
@@ -639,8 +639,8 @@ func yearMonthDayParser(text []rune, t *time.Time) (int, error) {
 	if err != nil {
 		return 0, fmt.Errorf("could not parse year number: %s", err)
 	}
-	if len(text) < progress || text[progress] != separator {
-		return 0, fmt.Errorf("could not parse year-month-day: [%c] not found after [%s]", separator, string(text[:progress]))
+	if len(text) <= progress || text[progress] != separator {
+		return 0, fmt.Errorf("could not parse year-month-day: [%c] not found after [%s]", separator, string(text))
 	}
 	progress += 1
 
@@ -649,8 +649,8 @@ func yearMonthDayParser(text []rune, t *time.Time) (int, error) {
 		return 0, fmt.Errorf("could not parse month number: %s", err)
 	}
 	progress += mProgress
-	if len(text) < progress || text[progress] != separator {
-		return 0, fmt.Errorf("could not parse year-month-day: [%c] not found after [%s]", separator, string(text[:progress]))
+	if len(text) <= progress || text[progress] != separator {
+		return 0, fmt.Errorf("could not parse year-month-day: [%c] not found after [%s]", separator, string(text))
 	}
 
 	progress += 1
@@ -895,11 +895,11 @@ func hourMinuteParser(text []rune, t *time.Time) (int, error) {
 	if err != nil {
 		return 0, fmt.Errorf("could not parse hour: %s", err)
 	}
-	if text[hProgress] != ':' {
-		return 0, fmt.Errorf("could not parse hour:minute format: character after hour [%s] is not a `:`", string(text[:hProgress]))
+	if len(text) <= hProgress || text[hProgress] != ':' {
+		return 0, fmt.Errorf("could not parse hour:minute format: character after hour [%s] is not a [:]", string(text))
 	}
 	hProgress += 1
-	mProgress, m, err := parseDigitRespectingOptionalPlaces(text, 0, 59)
+	mProgress, m, err := parseDigitRespectingOptionalPlaces(text[hProgress:], 0, 59)
 	if err != nil {
 		return 0, fmt.Errorf("could not parse minute: %s", err)
 	}

--- a/internal/function_time_parser.go
+++ b/internal/function_time_parser.go
@@ -639,7 +639,7 @@ func yearMonthDayParser(text []rune, t *time.Time) (int, error) {
 	if err != nil {
 		return 0, fmt.Errorf("could not parse year number: %s", err)
 	}
-	if text[progress] != separator {
+	if len(text) < progress || text[progress] != separator {
 		return 0, fmt.Errorf("could not parse year-month-day: [%c] not found after [%s]", separator, string(text[:progress]))
 	}
 	progress += 1
@@ -649,7 +649,7 @@ func yearMonthDayParser(text []rune, t *time.Time) (int, error) {
 		return 0, fmt.Errorf("could not parse month number: %s", err)
 	}
 	progress += mProgress
-	if text[progress] != separator {
+	if len(text) < progress || text[progress] != separator {
 		return 0, fmt.Errorf("could not parse year-month-day: [%c] not found after [%s]", separator, string(text[:progress]))
 	}
 
@@ -807,7 +807,7 @@ func parseDigitRespectingOptionalPlaces(text []rune, minNumber int64, maxNumber 
 
 	// These parts have already been parsed/formatted once, we don't expect this error to occur, but must handle anyway
 	if err != nil {
-		return 0, 0, fmt.Errorf("%s", err)
+		return 0, 0, err
 	}
 
 	if result > maxNumber {

--- a/internal/function_time_parser.go
+++ b/internal/function_time_parser.go
@@ -769,11 +769,6 @@ func minuteFormatter(t *time.Time) ([]rune, error) {
 	return []rune(fmt.Sprintf("%02d", t.Minute())), nil
 }
 
-// For %y, we always want to consume 2 digits, unless there's only 1 left to consume
-// For months, if we get 0/1 as the first digit, we want to consume the next digit
-// For days, if we get 0-3 as the first digit, we want to consume the next digit
-// For minutes, if we get 0-5, we want to consume the next digit
-
 func parseDigitRespectingOptionalPlaces(text []rune, minNumber int64, maxNumber int64) (int, int64, error) {
 	textLen := len(text)
 	places := len(fmt.Sprint(maxNumber))

--- a/internal/function_time_parser.go
+++ b/internal/function_time_parser.go
@@ -637,26 +637,26 @@ func yearMonthDayParser(text []rune, t *time.Time) (int, error) {
 	const separator = '-'
 	progress, y, err := parseDigitRespectingOptionalPlaces(text, 1, 9999)
 	if err != nil {
-		return 0, fmt.Errorf("could not parse year number: %s", err)
+		return 0, fmt.Errorf("could not parse year-month-day format: year number: %s", err)
 	}
 	if len(text) <= progress || text[progress] != separator {
-		return 0, fmt.Errorf("could not parse year-month-day: [%c] not found after [%s]", separator, string(text))
+		return 0, fmt.Errorf("could not parse year-month-day format: [%c] not found after [%s]", separator, string(text))
 	}
 	progress += 1
 
 	mProgress, m, err := parseDigitRespectingOptionalPlaces(text[progress:], 1, 12)
 	if err != nil {
-		return 0, fmt.Errorf("could not parse month number: %s", err)
+		return 0, fmt.Errorf("could not parse year-month-day format: month number: %s", err)
 	}
 	progress += mProgress
 	if len(text) <= progress || text[progress] != separator {
-		return 0, fmt.Errorf("could not parse year-month-day: [%c] not found after [%s]", separator, string(text))
+		return 0, fmt.Errorf("could not parse year-month-day format: [%c] not found after [%s]", separator, string(text))
 	}
 
 	progress += 1
 	dProgress, d, err := parseDigitRespectingOptionalPlaces(text[progress:], 1, 31)
 	if err != nil {
-		return 0, fmt.Errorf("could not parse day number: %s", err)
+		return 0, fmt.Errorf("could not parse year-month-day format: day number: %s", err)
 	}
 	progress += dProgress
 
@@ -893,7 +893,7 @@ func quarterFormatter(t *time.Time) ([]rune, error) {
 func hourMinuteParser(text []rune, t *time.Time) (int, error) {
 	hProgress, h, err := parseDigitRespectingOptionalPlaces(text, 0, 23)
 	if err != nil {
-		return 0, fmt.Errorf("could not parse hour: %s", err)
+		return 0, fmt.Errorf("could not parse hour:minute format: hour number: %s", err)
 	}
 	if len(text) <= hProgress || text[hProgress] != ':' {
 		return 0, fmt.Errorf("could not parse hour:minute format: character after hour [%s] is not a [:]", string(text))
@@ -901,7 +901,7 @@ func hourMinuteParser(text []rune, t *time.Time) (int, error) {
 	hProgress += 1
 	mProgress, m, err := parseDigitRespectingOptionalPlaces(text[hProgress:], 0, 59)
 	if err != nil {
-		return 0, fmt.Errorf("could not parse minute: %s", err)
+		return 0, fmt.Errorf("could not parse hour:minute format: minute number:  %s", err)
 	}
 	*t = time.Date(
 		int(t.Year()),

--- a/internal/function_time_parser.go
+++ b/internal/function_time_parser.go
@@ -770,6 +770,10 @@ func minuteFormatter(t *time.Time) ([]rune, error) {
 }
 
 func parseDigitRespectingOptionalPlaces(text []rune, minNumber int64, maxNumber int64) (int, int64, error) {
+	// Given a target value of `minNumber` and `maxNumber`, parse the given text up to `maxNumber`'s places
+	// If a non-digit character is encountered, consider the digit parsed and move on
+	// e.g. ('3', 0, 99) == 3  ('03', 0, 99) == 3 ('04/', 0, 999) == 4
+
 	textLen := len(text)
 	places := len(fmt.Sprint(maxNumber))
 	var parts []string
@@ -777,7 +781,7 @@ func parseDigitRespectingOptionalPlaces(text []rune, minNumber int64, maxNumber 
 		return 0, 0, fmt.Errorf("empty text")
 	}
 
-	// Format tokens require at most `places` characters and at least 1 character
+	// Format tokens require at least 1 character most `places` characters
 	steps := places
 	if textLen < places {
 		steps = textLen

--- a/internal/function_time_parser.go
+++ b/internal/function_time_parser.go
@@ -519,23 +519,17 @@ func centuryFormatter(t *time.Time) ([]rune, error) {
 }
 
 func yearWithoutCenturyParser(text []rune, t *time.Time) (int, error) {
-	const yearLen = 2
-	if len(text) > yearLen {
-		return 0, fmt.Errorf("unexpected year number")
-	}
-	year, err := strconv.ParseInt(string(text), 10, 64)
+	progress, year, err := parseDigitRespectingOptionalPlaces(text, 0, 99)
 	if err != nil {
-		return 0, fmt.Errorf("unexpected year number")
+		return 0, fmt.Errorf("could not parse year without century: %s", err)
 	}
-	if year < 0 {
-		return 0, fmt.Errorf("invalid year number %d", year)
-	}
-	century := 2000
 	if year >= 69 {
-		century = 1900
+		year += 1900
+	} else {
+		year += 2000
 	}
 	*t = time.Date(
-		century+int(year),
+		int(year),
 		t.Month(),
 		int(t.Day()),
 		int(t.Hour()),
@@ -544,7 +538,7 @@ func yearWithoutCenturyParser(text []rune, t *time.Time) (int, error) {
 		int(t.Nanosecond()),
 		t.Location(),
 	)
-	return len(text), nil
+	return progress, nil
 }
 
 func yearWithoutCenturyFormatter(t *time.Time) ([]rune, error) {
@@ -618,28 +612,21 @@ func monthDayYearFormatter(t *time.Time) ([]rune, error) {
 }
 
 func dayParser(text []rune, t *time.Time) (int, error) {
-	const dayLen = 2
-	if len(text) < dayLen {
-		return 0, fmt.Errorf("unexpected day number")
-	}
-	d, err := strconv.ParseInt(string(text[:dayLen]), 10, 64)
+	progress, days, err := parseDigitRespectingOptionalPlaces(text, 1, 31)
 	if err != nil {
-		return 0, fmt.Errorf("unexpected day number")
-	}
-	if d < 0 {
-		return 0, fmt.Errorf("invalid day number %d", d)
+		return 0, fmt.Errorf("could not parse day number: %s", err)
 	}
 	*t = time.Date(
 		int(t.Year()),
 		t.Month(),
-		int(d),
+		int(days),
 		int(t.Hour()),
 		int(t.Minute()),
 		int(t.Second()),
 		int(t.Nanosecond()),
 		t.Location(),
 	)
-	return dayLen, nil
+	return progress, nil
 }
 
 func dayFormatter(t *time.Time) ([]rune, error) {
@@ -647,32 +634,32 @@ func dayFormatter(t *time.Time) ([]rune, error) {
 }
 
 func yearMonthDayParser(text []rune, t *time.Time) (int, error) {
-	fmtLen := len("2021-01-20")
-	if len(text) < fmtLen {
-		return 0, fmt.Errorf("unexpected year-month-day format")
-	}
-	splitted := strings.Split(string(text[:fmtLen]), "-")
-	if len(splitted) != 3 {
-		return 0, fmt.Errorf("unexpected year-month-day format")
-	}
-	year := splitted[0]
-	month := splitted[1]
-	day := splitted[2]
-	if len(year) != 4 || len(month) != 2 || len(day) != 2 {
-		return 0, fmt.Errorf("unexpected year-month-day format")
-	}
-	y, err := strconv.ParseInt(year, 10, 64)
+	const separator = '-'
+	progress, y, err := parseDigitRespectingOptionalPlaces(text, 1, 9999)
 	if err != nil {
-		return 0, fmt.Errorf("unexpected year-month-day format: %w", err)
+		return 0, fmt.Errorf("could not parse year number: %s", err)
 	}
-	m, err := strconv.ParseInt(month, 10, 64)
+	if text[progress] != separator {
+		return 0, fmt.Errorf("could not parse year-month-day: [%c] not found after [%s]", separator, string(text[:progress]))
+	}
+	progress += 1
+
+	mProgress, m, err := parseDigitRespectingOptionalPlaces(text[progress:], 1, 12)
 	if err != nil {
-		return 0, fmt.Errorf("unexpected year-month-day format: %w", err)
+		return 0, fmt.Errorf("could not parse month number: %s", err)
 	}
-	d, err := strconv.ParseInt(day, 10, 64)
+	progress += mProgress
+	if text[progress] != separator {
+		return 0, fmt.Errorf("could not parse year-month-day: [%c] not found after [%s]", separator, string(text[:progress]))
+	}
+
+	progress += 1
+	dProgress, d, err := parseDigitRespectingOptionalPlaces(text[progress:], 1, 31)
 	if err != nil {
-		return 0, fmt.Errorf("unexpected year-month-day format: %w", err)
+		return 0, fmt.Errorf("could not parse day number: %s", err)
 	}
+	progress += dProgress
+
 	*t = time.Date(
 		int(y),
 		time.Month(m),
@@ -683,7 +670,7 @@ func yearMonthDayParser(text []rune, t *time.Time) (int, error) {
 		int(t.Nanosecond()),
 		t.Location(),
 	)
-	return fmtLen, nil
+	return progress, nil
 }
 
 func yearMonthDayFormatter(t *time.Time) ([]rune, error) {
@@ -709,16 +696,9 @@ func centuryISOFormatter(t *time.Time) ([]rune, error) {
 }
 
 func hourParser(text []rune, t *time.Time) (int, error) {
-	const hourLen = 2
-	if len(text) < hourLen {
-		return 0, fmt.Errorf("unexpected hour number")
-	}
-	h, err := strconv.ParseInt(string(text[:hourLen]), 10, 64)
+	progress, h, err := parseDigitRespectingOptionalPlaces(text, 0, 23)
 	if err != nil {
-		return 0, fmt.Errorf("unexpected hour number")
-	}
-	if h < 0 || h > 24 {
-		return 0, fmt.Errorf("invalid hour number %d", h)
+		return 0, fmt.Errorf("could not parse hour number: %s", err)
 	}
 	*t = time.Date(
 		int(t.Year()),
@@ -730,7 +710,7 @@ func hourParser(text []rune, t *time.Time) (int, error) {
 		int(t.Nanosecond()),
 		t.Location(),
 	)
-	return hourLen, nil
+	return progress, nil
 }
 
 func hourFormatter(t *time.Time) ([]rune, error) {
@@ -738,16 +718,9 @@ func hourFormatter(t *time.Time) ([]rune, error) {
 }
 
 func hour12Parser(text []rune, t *time.Time) (int, error) {
-	const hourLen = 2
-	if len(text) < hourLen {
-		return 0, fmt.Errorf("unexpected hour number")
-	}
-	h, err := strconv.ParseInt(string(text[:hourLen]), 10, 64)
+	progress, h, err := parseDigitRespectingOptionalPlaces(text, 0, 12)
 	if err != nil {
-		return 0, fmt.Errorf("unexpected hour number")
-	}
-	if h < 0 || h > 12 {
-		return 0, fmt.Errorf("invalid hour number %d", h)
+		return 0, fmt.Errorf("could not parse hour number: %s", err)
 	}
 	*t = time.Date(
 		int(t.Year()),
@@ -759,7 +732,7 @@ func hour12Parser(text []rune, t *time.Time) (int, error) {
 		int(t.Nanosecond()),
 		t.Location(),
 	)
-	return hourLen, nil
+	return progress, nil
 }
 
 func hour12Formatter(t *time.Time) ([]rune, error) {
@@ -775,16 +748,9 @@ func dayOfYearFormatter(t *time.Time) ([]rune, error) {
 }
 
 func minuteParser(text []rune, t *time.Time) (int, error) {
-	const minuteLen = 2
-	if len(text) < minuteLen {
-		return 0, fmt.Errorf("unexpected minute number")
-	}
-	m, err := strconv.ParseInt(string(text[:minuteLen]), 10, 64)
+	progress, m, err := parseDigitRespectingOptionalPlaces(text, 0, 59)
 	if err != nil {
-		return 0, fmt.Errorf("unexpected minute number")
-	}
-	if m < 0 || m > 59 {
-		return 0, fmt.Errorf("invalid minute number %d", m)
+		return 0, fmt.Errorf("unexpected minute number: %s", err)
 	}
 	*t = time.Date(
 		int(t.Year()),
@@ -796,28 +762,74 @@ func minuteParser(text []rune, t *time.Time) (int, error) {
 		int(t.Nanosecond()),
 		t.Location(),
 	)
-	return minuteLen, nil
+	return progress, nil
 }
 
 func minuteFormatter(t *time.Time) ([]rune, error) {
 	return []rune(fmt.Sprintf("%02d", t.Minute())), nil
 }
 
-func monthNumberParser(text []rune, t *time.Time) (int, error) {
-	const monthLen = 2
-	if len(text) < monthLen {
-		return 0, fmt.Errorf("unexpected month number")
+// For %y, we always want to consume 2 digits, unless there's only 1 left to consume
+// For months, if we get 0/1 as the first digit, we want to consume the next digit
+// For days, if we get 0-3 as the first digit, we want to consume the next digit
+// For minutes, if we get 0-5, we want to consume the next digit
+
+func parseDigitRespectingOptionalPlaces(text []rune, minNumber int64, maxNumber int64) (int, int64, error) {
+	textLen := len(text)
+	places := len(fmt.Sprint(maxNumber))
+	var parts []string
+	if textLen == 0 {
+		return 0, 0, fmt.Errorf("empty text")
 	}
-	m, err := strconv.ParseInt(string(text[:monthLen]), 10, 64)
+
+	// Format tokens require at most `places` characters and at least 1 character
+	steps := places
+	if textLen < places {
+		steps = textLen
+	}
+
+	for i := 0; i < steps; i++ {
+		char := string(text[i])
+		_, err := strconv.ParseInt(char, 10, 64)
+
+		// If we have encountered an error, we have encountered a non-digit
+		if err != nil {
+			// If we have not parsed any digits yet, the input text cannot be parsed
+			if len(parts) == 0 {
+				return 0, 0, fmt.Errorf("leading character is not a digit")
+			}
+			// If we already have parsed some digits, we assume the character was part of the format string (eg - or /)
+			break
+		}
+		parts = append(parts, char)
+	}
+
+	result, err := strconv.ParseInt(strings.Join(parts, ""), 10, 64)
+
+	// These parts have already been parsed/formatted once, we don't expect this error to occur, but must handle anyway
 	if err != nil {
-		return 0, fmt.Errorf("unexpected month number")
+		return 0, 0, fmt.Errorf("%s", err)
 	}
-	if m < 0 {
-		return 0, fmt.Errorf("invalid month number %d", m)
+
+	if result > maxNumber {
+		return 0, 0, fmt.Errorf("part [%d] is greater than maximum value [%d]", result, maxNumber)
+	}
+
+	if result < minNumber {
+		return 0, 0, fmt.Errorf("part [%d] is less than minimum value [%d]", result, minNumber)
+	}
+
+	return len(parts), result, nil
+}
+
+func monthNumberParser(text []rune, t *time.Time) (int, error) {
+	progress, months, err := parseDigitRespectingOptionalPlaces(text, 1, 12)
+	if err != nil {
+		return 0, fmt.Errorf("could not parse month: %s", err)
 	}
 	*t = time.Date(
 		t.Year(),
-		time.Month(m),
+		time.Month(months),
 		int(t.Day()),
 		int(t.Hour()),
 		int(t.Minute()),
@@ -825,7 +837,7 @@ func monthNumberParser(text []rune, t *time.Time) (int, error) {
 		int(t.Nanosecond()),
 		t.Location(),
 	)
-	return monthLen, nil
+	return progress, nil
 }
 
 func monthNumberFormatter(t *time.Time) ([]rune, error) {
@@ -880,26 +892,17 @@ func quarterFormatter(t *time.Time) ([]rune, error) {
 }
 
 func hourMinuteParser(text []rune, t *time.Time) (int, error) {
-	fmtLen := len("00:00")
-	if len(text) < fmtLen {
-		return 0, fmt.Errorf("unexpected hour:minute format")
-	}
-	splitted := strings.Split(string(text[:fmtLen]), ":")
-	if len(splitted) != 2 {
-		return 0, fmt.Errorf("unexpected hour:minute format")
-	}
-	hour := splitted[0]
-	minute := splitted[1]
-	if len(hour) != 2 || len(minute) != 2 {
-		return 0, fmt.Errorf("unexpected hour:minute format")
-	}
-	h, err := strconv.ParseInt(hour, 10, 64)
+	hProgress, h, err := parseDigitRespectingOptionalPlaces(text, 0, 23)
 	if err != nil {
-		return 0, fmt.Errorf("unexpected hour:minute format: %w", err)
+		return 0, fmt.Errorf("could not parse hour: %s", err)
 	}
-	m, err := strconv.ParseInt(minute, 10, 64)
+	if text[hProgress] != ':' {
+		return 0, fmt.Errorf("could not parse hour:minute format: character after hour [%s] is not a `:`", string(text[:hProgress]))
+	}
+	hProgress += 1
+	mProgress, m, err := parseDigitRespectingOptionalPlaces(text, 0, 59)
 	if err != nil {
-		return 0, fmt.Errorf("unexpected hour:minute format: %w", err)
+		return 0, fmt.Errorf("could not parse minute: %s", err)
 	}
 	*t = time.Date(
 		int(t.Year()),
@@ -911,7 +914,7 @@ func hourMinuteParser(text []rune, t *time.Time) (int, error) {
 		int(t.Nanosecond()),
 		t.Location(),
 	)
-	return fmtLen, nil
+	return mProgress + hProgress, nil
 }
 
 func hourMinuteFormatter(t *time.Time) ([]rune, error) {
@@ -919,16 +922,9 @@ func hourMinuteFormatter(t *time.Time) ([]rune, error) {
 }
 
 func secondParser(text []rune, t *time.Time) (int, error) {
-	const secondLen = 2
-	if len(text) < secondLen {
-		return 0, fmt.Errorf("unexpected second number")
-	}
-	s, err := strconv.ParseInt(string(text[:secondLen]), 10, 64)
+	progress, s, err := parseDigitRespectingOptionalPlaces(text, 0, 59)
 	if err != nil {
-		return 0, fmt.Errorf("unexpected second number")
-	}
-	if s < 0 || s > 59 {
-		return 0, fmt.Errorf("invalid second number %d", s)
+		return 0, fmt.Errorf("unexpected second number: %s", err)
 	}
 	*t = time.Date(
 		int(t.Year()),
@@ -940,7 +936,7 @@ func secondParser(text []rune, t *time.Time) (int, error) {
 		int(t.Nanosecond()),
 		t.Location(),
 	)
-	return secondLen, nil
+	return progress, nil
 }
 
 func secondFormatter(t *time.Time) ([]rune, error) {
@@ -1056,16 +1052,9 @@ func weekNumberZeroBaseFormatter(t *time.Time) ([]rune, error) {
 }
 
 func yearParser(text []rune, t *time.Time) (int, error) {
-	const yearLen = 4
-	if len(text) < yearLen {
-		return 0, fmt.Errorf("unexpected year number")
-	}
-	y, err := strconv.ParseInt(string(text[:yearLen]), 10, 64)
+	progress, y, err := parseDigitRespectingOptionalPlaces(text, 1, 9999)
 	if err != nil {
-		return 0, fmt.Errorf("unexpected year number")
-	}
-	if y < 0 {
-		return 0, fmt.Errorf("invalid year number %d", y)
+		return 0, fmt.Errorf("could not parse year: %s", err)
 	}
 	*t = time.Date(
 		int(y),
@@ -1077,7 +1066,7 @@ func yearParser(text []rune, t *time.Time) (int, error) {
 		int(t.Nanosecond()),
 		t.Location(),
 	)
-	return yearLen, nil
+	return progress, nil
 }
 
 func yearFormatter(t *time.Time) ([]rune, error) {

--- a/query_test.go
+++ b/query_test.go
@@ -3786,6 +3786,16 @@ SELECT date, EXTRACT(ISOYEAR FROM date), EXTRACT(YEAR FROM date), EXTRACT(MONTH 
 			expectedRows: [][]interface{}{{"2008-12-25"}},
 		},
 		{
+			name:        "parse date with %F no day field",
+			query:       `SELECT PARSE_DATE("%F", "2008-01") AS parsed`,
+			expectedErr: "could not parse year-month-day: [-] not found after [2008-01]",
+		},
+		{
+			name:        "parse date with %F no month field",
+			query:       `SELECT PARSE_DATE("%F", "2008") AS parsed`,
+			expectedErr: "could not parse year-month-day: [-] not found after [2008]",
+		},
+		{
 			name:         "parse date with %F",
 			query:        `SELECT PARSE_DATE("%F", "2008-12-25") AS parsed`,
 			expectedRows: [][]interface{}{{"2008-12-25"}},
@@ -3985,6 +3995,22 @@ SELECT date, EXTRACT(ISOYEAR FROM date), EXTRACT(YEAR FROM date), EXTRACT(MONTH 
 			name:         "time_trunc",
 			query:        `SELECT TIME_TRUNC(TIME "15:30:00", HOUR)`,
 			expectedRows: [][]interface{}{{"15:00:00"}},
+		},
+		{
+			name:         "parse_time with %R",
+			query:        `SELECT PARSE_TIME("%R", "14:30")`,
+			expectedRows: [][]interface{}{{"14:30:00"}},
+		},
+		{
+			name:        "parse_time with %R without minute element",
+			query:       `SELECT PARSE_TIME("%R", "14")`,
+			expectedErr: "could not parse hour:minute format: character after hour [14] is not a [:]",
+		},
+
+		{
+			name:        "parse_time with %R without separator",
+			query:       `SELECT PARSE_TIME("%R", "14")`,
+			expectedErr: "could not parse hour:minute format: character after hour [14] is not a [:]",
 		},
 		{
 			name:         "format_time with %R",

--- a/query_test.go
+++ b/query_test.go
@@ -3768,7 +3768,7 @@ SELECT date, EXTRACT(ISOYEAR FROM date), EXTRACT(YEAR FROM date), EXTRACT(MONTH 
 		{
 			name:         "parse date with single-digit month %m",
 			query:        `SELECT PARSE_DATE("%m", "03"), PARSE_DATE("%m", "3"), PARSE_DATE("%m%Y", "032024")`,
-			expectedRows: [][]interface{}{{"0001-03-01", "0001-03-01", "2024-03-01"}},
+			expectedRows: [][]interface{}{{"1970-03-01", "1970-03-01", "2024-03-01"}},
 		},
 		{
 			name:         "parse_date with %y",
@@ -3788,12 +3788,17 @@ SELECT date, EXTRACT(ISOYEAR FROM date), EXTRACT(YEAR FROM date), EXTRACT(MONTH 
 		{
 			name:        "parse date with %F no day field",
 			query:       `SELECT PARSE_DATE("%F", "2008-01") AS parsed`,
-			expectedErr: "could not parse year-month-day: [-] not found after [2008-01]",
+			expectedErr: "could not parse year-month-day format: [-] not found after [2008-01]",
 		},
 		{
 			name:        "parse date with %F no month field",
 			query:       `SELECT PARSE_DATE("%F", "2008") AS parsed`,
-			expectedErr: "could not parse year-month-day: [-] not found after [2008]",
+			expectedErr: "could not parse year-month-day format: [-] not found after [2008]",
+		},
+		{
+			name:        "parse date with %F separator but no month",
+			query:       `SELECT PARSE_DATE("%F", "2008-") AS parsed`,
+			expectedErr: "could not parse year-month-day format: month number: empty text",
 		},
 		{
 			name:         "parse date with %F",

--- a/query_test.go
+++ b/query_test.go
@@ -3744,6 +3744,32 @@ SELECT date, EXTRACT(ISOYEAR FROM date), EXTRACT(YEAR FROM date), EXTRACT(MONTH 
 			query:        `SELECT LAST_DAY(DATE '2008-11-10', WEEK(MONDAY)) AS last_day`,
 			expectedRows: [][]interface{}{{"2008-11-16"}},
 		},
+		// date parsing out of range values
+		{
+			name:        "parse date exceeding month maximum",
+			query:       `SELECT PARSE_DATE("%m", "14")`,
+			expectedErr: "could not parse month: part [14] is greater than maximum value [12]",
+		},
+		{
+			name:        "parse date beneath month minimum",
+			query:       `SELECT PARSE_DATE("%m", "0")`,
+			expectedErr: "could not parse month: part [0] is less than minimum value [1]",
+		},
+		{
+			name:        "parse date exceeding day maximum",
+			query:       `SELECT PARSE_DATE("%d", "32")`,
+			expectedErr: "could not parse day number: part [32] is greater than maximum value [31]",
+		},
+		{
+			name:        "parse date beneath day minimum",
+			query:       `SELECT PARSE_DATE("%d", "0")`,
+			expectedErr: "could not parse day number: part [0] is less than minimum value [1]",
+		},
+		{
+			name:         "parse date with single-digit month %m",
+			query:        `SELECT PARSE_DATE("%m", "03"), PARSE_DATE("%m", "3"), PARSE_DATE("%m%Y", "032024")`,
+			expectedRows: [][]interface{}{{"0001-03-01", "0001-03-01", "2024-03-01"}},
+		},
 		{
 			name:         "parse_date with %y",
 			query:        `SELECT PARSE_DATE("%y", '1'), PARSE_DATE("%y", '67'), PARSE_DATE("%y", '69')`,
@@ -3772,7 +3798,7 @@ SELECT date, EXTRACT(ISOYEAR FROM date), EXTRACT(YEAR FROM date), EXTRACT(MONTH 
 		{
 			name:        "parse date ( the year element is in different locations )",
 			query:       `SELECT PARSE_DATE("%Y %A %b %e", "Thursday Dec 25 2008")`,
-			expectedErr: "unexpected year number",
+			expectedErr: "could not parse year: leading character is not a digit",
 		},
 		{
 			name:         "safe parse date ( the year element is in different locations )",
@@ -3907,12 +3933,17 @@ SELECT date, EXTRACT(ISOYEAR FROM date), EXTRACT(YEAR FROM date), EXTRACT(MONTH 
 		{
 			name:        "parse datetime ( the year element is in different locations )",
 			query:       `SELECT PARSE_DATETIME("%a %b %e %Y %I:%M:%S", "Thu Dec 25 07:30:00 2008")`,
-			expectedErr: "unexpected year number",
+			expectedErr: "could not parse hour number: part [30] is greater than maximum value [12]",
 		},
 		{
 			name:        "parse datetime ( one of the year elements is missing )",
 			query:       `SELECT PARSE_DATETIME("%a %b %e %I:%M:%S", "Thu Dec 25 07:30:00 2008")`,
 			expectedErr: `found unused format element [' ' '2' '0' '0' '8']`,
+		},
+		{
+			name:         "parse datetime %F respectfully consuming digits",
+			query:        `SELECT PARSE_DATETIME("%F", "03-1-1"), PARSE_DATETIME("%F", "003-01-1"), PARSE_DATETIME("%F", "0003-1-11")`,
+			expectedRows: [][]interface{}{{"0003-01-01T00:00:00", "0003-01-01T00:00:00", "0003-01-11T00:00:00"}},
 		},
 
 		// time functions
@@ -3983,7 +4014,7 @@ SELECT date, EXTRACT(ISOYEAR FROM date), EXTRACT(YEAR FROM date), EXTRACT(MONTH 
 		{
 			name:        "parse time ( the seconds element is in different locations )",
 			query:       `SELECT PARSE_TIME("%S:%I:%M", "07:30:00")`,
-			expectedErr: "invalid hour number 30",
+			expectedErr: "could not parse hour number: part [30] is greater than maximum value [12]",
 		},
 		{
 			name:        "parse time ( one of the seconds elements is missing )",
@@ -4145,7 +4176,7 @@ SELECT date, EXTRACT(ISOYEAR FROM date), EXTRACT(YEAR FROM date), EXTRACT(MONTH 
 		{
 			name:        "parse timestamp ( the year element is in different locations )",
 			query:       `SELECT PARSE_TIMESTAMP("%a %b %e %Y %I:%M:%S", "Thu Dec 25 07:30:00 2008")`,
-			expectedErr: "unexpected year number",
+			expectedErr: "could not parse hour number: part [30] is greater than maximum value [12]",
 		},
 		{
 			name:        "parse timestamp ( one of the year elements is missing )",

--- a/query_test.go
+++ b/query_test.go
@@ -3699,6 +3699,11 @@ SELECT date, EXTRACT(ISOYEAR FROM date), EXTRACT(YEAR FROM date), EXTRACT(MONTH 
 			expectedRows: [][]interface{}{{"12/25/08"}},
 		},
 		{
+			name:         "format_date with %y",
+			query:        `SELECT FORMAT_DATE("%y", DATE "2008-12-25"), FORMAT_DATE("%y", DATE "2012-12-25")`,
+			expectedRows: [][]interface{}{{"08", "12"}},
+		},
+		{
 			name:         "format_date with %b-%d-%Y",
 			query:        `SELECT FORMAT_DATE("%b-%d-%Y", DATE "2008-12-25")`,
 			expectedRows: [][]interface{}{{"Dec-25-2008"}},
@@ -3738,6 +3743,11 @@ SELECT date, EXTRACT(ISOYEAR FROM date), EXTRACT(YEAR FROM date), EXTRACT(MONTH 
 			name:         "last_day with week(monday)",
 			query:        `SELECT LAST_DAY(DATE '2008-11-10', WEEK(MONDAY)) AS last_day`,
 			expectedRows: [][]interface{}{{"2008-11-16"}},
+		},
+		{
+			name:         "parse_date with %y",
+			query:        `SELECT PARSE_DATE("%y", '1'), PARSE_DATE("%y", '67'), PARSE_DATE("%y", '69')`,
+			expectedRows: [][]interface{}{{"2001-01-01", "2067-01-01", "1969-01-01"}},
 		},
 		{
 			name:         "parse date with %A %b %e %Y",


### PR DESCRIPTION
Year numbers without leading zeros are allowed

Closes goccy/go-zetasqlite#134
Closes goccy/go-zetasqlite#137
Part of #138 