### PR TITLE
Recidinick/implement.day of year parser

### DIFF
--- a/internal/function_time_parser.go
+++ b/internal/function_time_parser.go
@@ -746,7 +746,24 @@ func hour12Formatter(t *time.Time) ([]rune, error) {
 }
 
 func dayOfYearParser(text []rune, t *time.Time) (int, error) {
-	return 0, fmt.Errorf("unimplemented day of year matcher")
+	progress, d, err := parseDigitRespectingOptionalPlaces(text, 0, 366)
+	dayOfYear := int(d) - 1
+	year := int(t.Year())
+	if err != nil {
+		return 0, fmt.Errorf("could not parse day of year number: %s", err)
+	}
+	stubDate := time.Date(year, time.January, 1, 0, 0, 0, 0, time.UTC).AddDate(0, 0, dayOfYear)
+	*t = time.Date(
+		year,
+		stubDate.Month(),
+		int(stubDate.Day()),
+		int(t.Hour()),
+		int(t.Minute()),
+		int(t.Second()),
+		int(t.Nanosecond()),
+		t.Location(),
+	)
+	return progress, nil
 }
 
 func dayOfYearFormatter(t *time.Time) ([]rune, error) {

--- a/internal/function_time_parser.go
+++ b/internal/function_time_parser.go
@@ -747,11 +747,11 @@ func hour12Formatter(t *time.Time) ([]rune, error) {
 
 func dayOfYearParser(text []rune, t *time.Time) (int, error) {
 	progress, d, err := parseDigitRespectingOptionalPlaces(text, 0, 366)
-	dayOfYear := int(d) - 1
-	year := int(t.Year())
 	if err != nil {
 		return 0, fmt.Errorf("could not parse day of year number: %s", err)
 	}
+	dayOfYear := int(d) - 1
+	year := int(t.Year())
 	stubDate := time.Date(year, time.January, 1, 0, 0, 0, 0, time.UTC).AddDate(0, 0, dayOfYear)
 	*t = time.Date(
 		year,

--- a/internal/function_time_parser.go
+++ b/internal/function_time_parser.go
@@ -746,7 +746,7 @@ func hour12Formatter(t *time.Time) ([]rune, error) {
 }
 
 func dayOfYearParser(text []rune, t *time.Time) (int, error) {
-	progress, d, err := parseDigitRespectingOptionalPlaces(text, 0, 366)
+	progress, d, err := parseDigitRespectingOptionalPlaces(text, 1, 366)
 	if err != nil {
 		return 0, fmt.Errorf("could not parse day of year number: %s", err)
 	}

--- a/query_test.go
+++ b/query_test.go
@@ -3982,6 +3982,48 @@ WITH example AS (
 			},
 		},
 		{
+			name:  "base date is epoch julian",
+			query: `SELECT PARSE_DATE("%j", "001")`,
+			expectedRows: [][]interface{}{
+				{"1970-01-01"},
+			},
+		},
+		{
+			name:  "base date is epoch julian different day",
+			query: `SELECT PARSE_DATE("%j", "002")`,
+			expectedRows: [][]interface{}{
+				{"1970-01-02"},
+			},
+		},
+		{
+			name:  "parse date with two digit year and julian day",
+			query: `SELECT PARSE_DATE("%y%j", "70002")`,
+			expectedRows: [][]interface{}{
+				{"1970-01-02"},
+			},
+		},
+		{
+			name:  "parse date with two digit year before 2000 and julian day",
+			query: `SELECT PARSE_DATE("%y%j", "95033")`,
+			expectedRows: [][]interface{}{
+				{"1995-02-02"},
+			},
+		},
+		{
+			name:  "parse date with two digit year after 2000 and julian day",
+			query: `SELECT PARSE_DATE("%y%j", "22120")`,
+			expectedRows: [][]interface{}{
+				{"2022-04-30"},
+			},
+		},
+		{
+			name:  "parse date with two digit year after 2000 and julian day leap year",
+			query: `SELECT PARSE_DATE("%y%j", "24120")`,
+			expectedRows: [][]interface{}{
+				{"2024-04-29"},
+			},
+		},
+		{
 			name: "extract date",
 			query: `
 SELECT date, EXTRACT(ISOYEAR FROM date), EXTRACT(YEAR FROM date), EXTRACT(MONTH FROM date),

--- a/query_test.go
+++ b/query_test.go
@@ -3989,6 +3989,13 @@ WITH example AS (
 			},
 		},
 		{
+			name:  "base datetime is epoch julian",
+			query: `SELECT PARSE_DATETIME("%j", "001")`,
+			expectedRows: [][]interface{}{
+				{"1970-01-01T00:00:00"},
+			},
+		},
+		{
 			name:  "base date is epoch julian different day",
 			query: `SELECT PARSE_DATE("%j", "002")`,
 			expectedRows: [][]interface{}{
@@ -4010,6 +4017,13 @@ WITH example AS (
 			},
 		},
 		{
+			name:  "parse datetime with two digit year before 2000 and julian day",
+			query: `SELECT PARSE_DATETIME("%y%j%H%M%S", "95033101010")`,
+			expectedRows: [][]interface{}{
+				{"1995-02-02T10:10:10"},
+			},
+		},
+		{
 			name:  "parse date with two digit year after 2000 and julian day",
 			query: `SELECT PARSE_DATE("%y%j", "22120")`,
 			expectedRows: [][]interface{}{
@@ -4017,10 +4031,24 @@ WITH example AS (
 			},
 		},
 		{
+			name:  "parse datetime with two digit year after 2000 and julian day",
+			query: `SELECT PARSE_DATETIME("%y%j-%H:%M:%S", "22120-10:10:10")`,
+			expectedRows: [][]interface{}{
+				{"2022-04-30T10:10:10"},
+			},
+		},
+		{
 			name:  "parse date with two digit year after 2000 and julian day leap year",
 			query: `SELECT PARSE_DATE("%y%j", "24120")`,
 			expectedRows: [][]interface{}{
 				{"2024-04-29"},
+			},
+		},
+		{
+			name:  "parse datetime with two digit year after 2000 and julian day leap year",
+			query: `SELECT PARSE_DATETIME("%y%j %H:%M", "24120 02:04")`,
+			expectedRows: [][]interface{}{
+				{"2024-04-29T02:04:00"},
 			},
 		},
 		{

--- a/query_test.go
+++ b/query_test.go
@@ -4171,6 +4171,16 @@ SELECT date, EXTRACT(ISOYEAR FROM date), EXTRACT(YEAR FROM date), EXTRACT(MONTH 
 			expectedErr: "error parsing [0] with format [%d]: could not parse day number: part [0] is less than minimum value [1]",
 		},
 		{
+			name:        "parse date exceeding day of year maximum",
+			query:       `SELECT PARSE_DATE("%j", "367")`,
+			expectedErr: "error parsing [367] with format [%j]: could not parse day of year number: part [367] is greater than maximum value [366]",
+		},
+		{
+			name:        "parse date beneath day of year minimum",
+			query:       `SELECT PARSE_DATE("%j", "0")`,
+			expectedErr: "error parsing [0] with format [%j]: could not parse day of year number: part [0] is less than minimum value [1]",
+		},
+		{
 			name:         "parse date with single-digit month %m",
 			query:        `SELECT PARSE_DATE("%m", "03"), PARSE_DATE("%m", "3"), PARSE_DATE("%m%Y", "032024")`,
 			expectedRows: [][]interface{}{{"1970-03-01", "1970-03-01", "2024-03-01"}},


### PR DESCRIPTION
Implements `dayOfYearParser` in `internal/function_time_parser.go`. It tests assorted PARSE_DATE and PARSE_DATETIME calls, including on a leap year, as well as invalid day of year handling.

Closes #196