### PR TITLE
Implement unary minus operator

### DIFF
--- a/internal/function_bind.go
+++ b/internal/function_bind.go
@@ -3,6 +3,7 @@ package internal
 import (
 	"errors"
 	"fmt"
+	"math"
 	"sync"
 
 	"github.com/goccy/go-json"
@@ -182,6 +183,23 @@ func bindOpDiv(args ...Value) (Value, error) {
 		return nil, nil
 	}
 	return OP_DIV(args[0], args[1])
+}
+
+func bindUnaryMinus(args ...Value) (Value, error) {
+	if existsNull(args) {
+		return nil, nil
+	}
+	v, ok := args[0].(IntValue)
+	if ok {
+		i, err := v.ToInt64()
+		if err != nil {
+			return nil, err
+		}
+		if i == math.MinInt64 {
+			return nil, fmt.Errorf("int64 overflow: -%d", i)
+		}
+	}
+	return SAFE_NEGATE(args[0])
 }
 
 func bindEqual(args ...Value) (Value, error) {

--- a/internal/function_register.go
+++ b/internal/function_register.go
@@ -13,6 +13,7 @@ var normalFuncs = []*FuncInfo{
 	{Name: "subtract", BindFunc: bindSub},
 	{Name: "multiply", BindFunc: bindMul},
 	{Name: "divide", BindFunc: bindOpDiv},
+	{Name: "unary_minus", BindFunc: bindUnaryMinus},
 	{Name: "equal", BindFunc: bindEqual},
 	{Name: "not_equal", BindFunc: bindNotEqual},
 	{Name: "greater", BindFunc: bindGreater},

--- a/query_test.go
+++ b/query_test.go
@@ -68,9 +68,25 @@ UNION ALL
 			expectedRows: [][]interface{}{{int64(1)}},
 		},
 		{
-			name:         "unary minus operator",
+			name:         "unary minus operator with literal",
 			query:        "SELECT -2",
 			expectedRows: [][]interface{}{{int64(-2)}},
+		},
+		{
+			name: "unary minus operator with column",
+			query: `WITH x AS (
+						SELECT 2 AS i, 2.0 AS f
+						UNION ALL
+						SELECT NULL, -9223372036854775808
+					) SELECT -i, -f FROM x`,
+			expectedRows: [][]interface{}{
+				{int64(-2), float64(-2.0)},
+				{nil, float64(9223372036854775808)}},
+		},
+		{
+			name:        "unary minus operator overflow",
+			query:       "WITH x AS (SELECT -9223372036854775807-1 as v) SELECT -v FROM x",
+			expectedErr: "int64 overflow: --9223372036854775808",
 		},
 		{
 			name:         "bit not operator",


### PR DESCRIPTION
This Pull Request closes https://github.com/goccy/bigquery-emulator/issues/217

I added a unary minus operator because it was not implemented before. 
As tested [here](https://github.com/goccy/go-zetasqlite/blob/b6dd6a5c9272ce2c804b47446646d42ebdf9450a/query_test.go#L70-L74), It seems to work fine with number literals, but using `-` on columns causes an error as described in the linked issue.

In this PR, I implemented the unary minus operator. It is basically the same as the SAFE_NEGATE function, as shown in the link below. What different is, an exception occurs when there's an overflow.
https://cloud.google.com/bigquery/docs/reference/standard-sql/mathematical_functions#safe_negate

## out of scope

This unary minus operator implementation uses `SAFE_NEGATE` inside, but do not change `SAFE_NEGATE` behaviour. Currently, `SAFE_NEGATE` has some incompatibilities. For example,
* Given math.MinInt64, it returns an unexpected value on ubuntu. (expected 9223372036854775807 but returns -9223372036854775808)
* Given `NaN`, `NaN` is expected but it returns `nil`
* Given a large BigNumeric, it returns an unexpected value.