### PR TITLE
Allow users of the driver to disable query formatting; support named parameters for `QueryStmt`

### DIFF
--- a/context.go
+++ b/context.go
@@ -7,6 +7,16 @@ import (
 	"github.com/goccy/go-zetasqlite/internal"
 )
 
+// DisableQueryFormattingKey use to disable query formatting for queries that require raw SQLite access
+type DisableQueryFormattingKey = internal.DisableQueryFormattingKey
+
+// WithQueryFormattingDisabled for queries that require raw SQLite SQL
+// This is useful for queries that do not require additional functionality from go-zetasqlite
+// Utilizing this option often allows the SQLite query planner to generate more efficient plans
+func WithQueryFormattingDisabled(ctx context.Context) context.Context {
+	return context.WithValue(ctx, internal.DisableQueryFormattingKey{}, true)
+}
+
 // WithCurrentTime use to replace the current time with the specified time.
 // To replace the time, you need to pass the returned context as an argument to QueryContext.
 // `CURRENT_DATE`, `CURRENT_DATETIME`, `CURRENT_TIME`, `CURRENT_TIMESTAMP` functions are targeted.


### PR DESCRIPTION
As part of goccy/bigquery-emulator#294 we want to be able to disable query formatting for queries in order to fine-tune the query plans generated by SQLite.

This implements an option that can be used to disable formatting as well as supports named parameters.