### PR TITLE
Making MERGE more robust in handling edge-cases

### DIFF
--- a/internal/analyzer.go
+++ b/internal/analyzer.go
@@ -76,6 +76,7 @@ func newAnalyzerOptions() (*zetasql.AnalyzerOptions, error) {
 		zetasql.FeatureV13Pivot,
 		zetasql.FeatureV13Unpivot,
 		zetasql.FeatureCreateTableAsSelectColumnList,
+		zetasql.FeatureV13OmitInsertColumnList,
 	})
 	langOpt.SetSupportedStatementKinds([]ast.Kind{
 		ast.BeginStmt,

--- a/internal/analyzer.go
+++ b/internal/analyzer.go
@@ -583,7 +583,7 @@ func (a *Analyzer) newMergeStmtAction(ctx context.Context, _ string, args []driv
 		sourceColumn *ast.Column
 		targetColumn *ast.Column
 	)
-	if strings.Contains(sourceTable, colA.Column().TableName()) {
+	if strings.Contains(sourceTable, colA.Column().TableName()) && !strings.Contains(sourceTable, colB.Column().TableName()) {
 		sourceColumn = colA.Column()
 		targetColumn = colB.Column()
 	} else {
@@ -598,7 +598,7 @@ func (a *Analyzer) newMergeStmtAction(ctx context.Context, _ string, args []driv
 	}
 	var stmts []string
 	stmts = append(stmts, fmt.Sprintf(
-		"CREATE TABLE zetasqlite_merged_table AS SELECT DISTINCT * FROM (SELECT * FROM %[1]s LEFT JOIN %[2]s ON %[3]s UNION ALL SELECT * FROM %[2]s LEFT JOIN %[1]s ON %[3]s)",
+		"CREATE TABLE zetasqlite_merged_table AS SELECT DISTINCT * FROM (SELECT * FROM (%[1]s) LEFT JOIN (%[2]s) ON %[3]s UNION ALL SELECT * FROM (%[2]s) LEFT JOIN (%[1]s) ON %[3]s)",
 		sourceTable, targetTable, expr,
 	))
 

--- a/query_test.go
+++ b/query_test.go
@@ -5898,6 +5898,58 @@ SELECT * FROM table2;
 `,
 			expectedRows: [][]interface{}{{"test"}},
 		},
+		{
+			name: "merge two tables with empty source",
+			query: `
+CREATE TEMP TABLE target(id INT64, name STRING);
+CREATE TEMP TABLE source(id INT64, name STRING);
+MERGE target T USING source S ON T.id = S.id
+WHEN MATCHED THEN UPDATE SET id = S.id, name = S.name
+WHEN NOT MATCHED THEN INSERT (id, name) VALUES (id, name);
+SELECT * FROM target;
+`,
+			expectedRows: [][]interface{}{},
+		},
+		{
+			name: "merge two tables with non-empty source",
+			query: `
+CREATE TEMP TABLE target(id INT64, name STRING);
+CREATE TEMP TABLE source(id INT64, name STRING);
+INSERT INTO source(id, name) VALUES (1, "test");
+MERGE target T USING source S ON T.id = S.id
+WHEN MATCHED THEN UPDATE SET id = S.id, name = S.name
+WHEN NOT MATCHED THEN INSERT (id, name) VALUES (id, name);
+SELECT * FROM target;
+`,
+			expectedRows: [][]interface{}{{int64(1), "test"}},
+		},
+		{
+			name: "merge two tables where target table name is substring of source table name",
+			query: `
+CREATE TEMP TABLE target(id INT64, name STRING);
+CREATE TEMP TABLE tmp_target_123(id INT64, name STRING);
+INSERT INTO tmp_target_123(id, name) VALUES (1, "test");
+MERGE target T USING tmp_target_123 S ON T.id = S.id
+WHEN MATCHED THEN UPDATE SET id = S.id, name = S.name
+WHEN NOT MATCHED THEN INSERT (id, name) VALUES (id, name);
+SELECT * FROM target;
+`,
+			expectedRows: [][]interface{}{{int64(1), "test"}},
+		},
+		{
+			name: "merge two tables where source table is evaluated using a SELECT expression",
+			query: `
+CREATE TEMP TABLE target(id INT64, name STRING);
+CREATE TEMP TABLE source(id INT64, name STRING);
+INSERT INTO source(id, name) VALUES (1, "test");
+INSERT INTO source(id, name) VALUES (2, "test2");
+MERGE target T USING (SELECT * FROM source) S ON T.id = S.id
+WHEN MATCHED THEN UPDATE SET id = S.id, name = S.name
+WHEN NOT MATCHED THEN INSERT (id, name) VALUES (id, name);
+SELECT * FROM target;
+`,
+			expectedRows: [][]interface{}{{int64(1), "test"}, {int64(2), "test2"}},
+		},
 	} {
 		test := test
 		t.Run(test.name, func(t *testing.T) {


### PR DESCRIPTION
Closes: https://github.com/goccy/bigquery-emulator/issues/163

The MERGE statement currently works fine but on a few edge cases:

1. When the INSERT action inside MERGE uses `ROW` instead of specifying a column list, it raises the error. We can simply add the feature `FeatureV13OmitInsertColumnList` to fix that.

```sql
/* ❌ Doesn't work currently because there's no column values given in INSERT */
MERGE target T USING source S ON T.id = S.id
WHEN NOT MATCHED THEN INSERT ROW;
```

2. When the source table is evaluated using a SELECT expression rather than just a name, it raises an error. This is fixed by adding additional parenthesis around the table joins.

```sql
/* ❌ Doesn't work currently as source table is evaluated using a SELECT */
MERGE target T USING (SELECT * FROM source) S ON T.id = S.id
WHEN NOT MATCHED THEN INSERT (id, name) VALUES (id, name);
```

3. When the target table name is a substring of source table name, it doesn't properly merge as it switches the target and source tables, because of [this check](https://github.com/goccy/go-zetasqlite/blob/9d65c7df351bc4b9056c6610acffdfbcdfc8c1b9/internal/analyzer.go#L586).

```sql
/* ❌ Doesn't work currently as target table name is a substring of source table name */
MERGE target T USING target_tmp S ON T.id = S.id
WHEN NOT MATCHED THEN INSERT (id, name) VALUES (id, name);
```

This PR aims to fix all these issues while adding some test cases for basic merge statements.