### PR TITLE
Fix return type for INT64 and FLOAT64 functions

### DIFF
--- a/internal/function_bind.go
+++ b/internal/function_bind.go
@@ -1560,7 +1560,11 @@ func bindInt64(args ...Value) (Value, error) {
 	if len(args) != 1 {
 		return nil, fmt.Errorf("INT64: invalid argument num %d", len(args))
 	}
-	return args[0], nil
+	value, err := args[0].ToInt64()
+	if err != nil {
+		return nil, err
+	}
+	return IntValue(value), nil
 }
 
 func bindDouble(args ...Value) (Value, error) {
@@ -1573,9 +1577,17 @@ func bindDouble(args ...Value) (Value, error) {
 	}
 	switch mode {
 	case "exact":
-		return args[0], nil
+		value, err := args[0].ToFloat64()
+		if err != nil {
+			return nil, err
+		}
+		return FloatValue(value), nil
 	case "round":
-		return args[0], nil
+		value, err := args[0].ToFloat64()
+		if err != nil {
+			return nil, err
+		}
+		return FloatValue(value), nil
 	}
 	return nil, fmt.Errorf("unexpected wide_number_mode: %s", mode)
 }

--- a/query_test.go
+++ b/query_test.go
@@ -5567,6 +5567,26 @@ FROM
 				{"false", "boolean"},
 			},
 		},
+		{
+			name:         "json_sum_int64 simple",
+			query:        `SELECT SUM(INT64(x)) AS sum FROM UNNEST([JSON '100', JSON '200', JSON '300']) AS x`,
+			expectedRows: [][]interface{}{{int64(600)}},
+		},
+		{
+			name:         "json_sum_int64 key",
+			query:        `SELECT SUM(INT64(x.count)) AS sum FROM UNNEST([JSON '{"count":100}', JSON '{"count":200}', JSON '{"count":300}']) AS x`,
+			expectedRows: [][]interface{}{{int64(600)}},
+		},
+		{
+			name:         "json_sum_float64 simple",
+			query:        `SELECT SUM(FLOAT64(x)) AS sum FROM UNNEST([JSON '1.5', JSON '2.5', JSON '1.1']) AS x`,
+			expectedRows: [][]interface{}{{float64(5.1)}},
+		},
+		{
+			name:         "json_sum_float64_round simple",
+			query:        `SELECT SUM(ROUND(FLOAT64(x))) AS sum FROM UNNEST([JSON '1.6', JSON '1.1', JSON '1.1']) AS x`,
+			expectedRows: [][]interface{}{{float64(4.0)}},
+		},
 
 		// subquery expr
 		{


### PR DESCRIPTION
When `INT64` or `FLOAT64` functions are applied, the value returned doesn't change type. In the following example the return type is still `JSON` and aggregation `add` cannot be performed over json type.
```sql
SELECT SUM(INT64(x)) AS sum FROM UNNEST([JSON '100', JSON '200', JSON '300']) AS x
```

Forcing the return type in `bindInt64` and `bindDouble` to fix it.