### PR TITLE
Fix DATE_DIFF handling of diff remainder

### DIFF
--- a/internal/function_date.go
+++ b/internal/function_date.go
@@ -144,18 +144,12 @@ func DATE_DIFF(a, b time.Time, part string) (Value, error) {
 		return IntValue(result), nil
 	}
 
-	diff := a.Sub(b)
-
 	switch part {
 	case "DAY":
-		diffDay := diff / (24 * time.Hour)
-		mod := diff % (24 * time.Hour)
-		if mod > 0 {
-			diffDay++
-		} else if mod < 0 {
-			diffDay--
+		if a.After(b) {
+			return IntValue(diffDay(a, b)), nil
 		}
-		return IntValue(diffDay), nil
+		return IntValue(-1 * diffDay(b, a)), nil
 	case "ISOWEEK":
 		return IntValue((a.Year()-b.Year())*48 + weekA - weekB), nil
 	case "MONTH":
@@ -310,4 +304,25 @@ func addYear(t time.Time, y int) time.Time {
 		return first.AddDate(y, 1, -1)
 	}
 	return t.AddDate(y, 0, 0)
+}
+
+func diffDay(a, b time.Time) int64 {
+	diff := a.Sub(b)
+	if diff < 24*time.Hour {
+		if a.Day() == b.Day() {
+			return 0
+		}
+		return 1
+	}
+	diff = truncateToDay(a).Sub(b)
+	diffDay := diff / (24 * time.Hour)
+	mod := diff % (24 * time.Hour)
+	if mod > 0 {
+		diffDay++
+	}
+	return int64(diffDay)
+}
+
+func truncateToDay(t time.Time) time.Time {
+	return time.Date(t.Year(), t.Month(), t.Day(), 0, 0, 0, 0, t.Location())
 }

--- a/query_test.go
+++ b/query_test.go
@@ -4212,7 +4212,7 @@ SELECT date, EXTRACT(ISOYEAR FROM date), EXTRACT(YEAR FROM date), EXTRACT(MONTH 
 		},
 		{
 			name: "date_diff with week day",
-			query: `SELECT 
+			query: `SELECT
   DATE_DIFF(DATE '2024-03-19', DATE '2024-03-24', WEEK(SUNDAY)),
   DATE_DIFF(DATE '2024-03-19', DATE '2024-03-24', WEEK(MONDAY)),
   DATE_DIFF(DATE '2024-03-25', DATE '2024-03-19', WEEK(SUNDAY)),
@@ -4234,7 +4234,7 @@ SELECT date, EXTRACT(ISOYEAR FROM date), EXTRACT(YEAR FROM date), EXTRACT(MONTH 
 		},
 		{
 			name: "datetime_diff with week day",
-			query: `SELECT 
+			query: `SELECT
   DATETIME_DIFF(DATETIME '2024-03-19', DATETIME '2024-03-24', WEEK(SUNDAY)),
   DATETIME_DIFF(DATETIME '2024-03-19', DATETIME '2024-03-24', WEEK(MONDAY)),
   DATETIME_DIFF(DATETIME '2024-03-25', DATETIME '2024-03-19', WEEK(SUNDAY)),
@@ -4256,7 +4256,7 @@ SELECT date, EXTRACT(ISOYEAR FROM date), EXTRACT(YEAR FROM date), EXTRACT(MONTH 
 		},
 		{
 			name: "datetime_diff with week day 1 week",
-			query: `SELECT 
+			query: `SELECT
 	DATETIME_DIFF(DATETIME '2024-02-21', DATETIME '2024-02-29', WEEK(MONDAY))`,
 			expectedRows: [][]interface{}{{
 				int64(-1),
@@ -4272,7 +4272,7 @@ SELECT date, EXTRACT(ISOYEAR FROM date), EXTRACT(YEAR FROM date), EXTRACT(MONTH 
 		},
 		{
 			name: "timestamp diff with week day",
-			query: `SELECT 
+			query: `SELECT
   TIMESTAMP_DIFF(DATETIME '2024-03-19', DATETIME '2024-03-24', WEEK(SUNDAY)),
   TIMESTAMP_DIFF(DATETIME '2024-03-19', DATETIME '2024-03-24', WEEK(MONDAY)),
   TIMESTAMP_DIFF(DATETIME '2024-03-25', DATETIME '2024-03-19', WEEK(SUNDAY)),
@@ -4524,9 +4524,34 @@ SELECT date, EXTRACT(ISOYEAR FROM date), EXTRACT(YEAR FROM date), EXTRACT(MONTH 
 			expectedRows: [][]interface{}{{"2023-02-28T00:00:00"}},
 		},
 		{
-			name:         "datetime_diff with day",
+			name:         "datetime_diff with day, more than 24 hours",
 			query:        `SELECT DATETIME_DIFF(DATETIME "2010-07-07 10:20:00", DATETIME "2008-12-25 15:30:00", DAY)`,
 			expectedRows: [][]interface{}{{int64(559)}},
+		},
+		{
+			name:         "datetime_diff with day, less than 24 hours and does not cross boundary",
+			query:        `SELECT DATETIME_DIFF(DATETIME "2024-02-01 16:00:00", DATETIME "2024-02-01 15:30:00", DAY)`,
+			expectedRows: [][]interface{}{{int64(0)}},
+		},
+		{
+			name:         "datetime_diff with day, less than 24 hours and does cross boundary",
+			query:        `SELECT DATETIME_DIFF(DATETIME "2024-02-02 02:00:00", DATETIME "2024-02-01 15:30:00", DAY)`,
+			expectedRows: [][]interface{}{{int64(1)}},
+		},
+		{
+			name:         "datetime_diff with day, more than 24 hours, reverse",
+			query:        `SELECT DATETIME_DIFF(DATETIME "2008-12-25 15:30:00", DATETIME "2010-07-07 10:20:00", DAY)`,
+			expectedRows: [][]interface{}{{int64(-559)}},
+		},
+		{
+			name:         "datetime_diff with day, less than 24 hours and does not cross boundary, reverse",
+			query:        `SELECT DATETIME_DIFF(DATETIME "2024-02-01 15:30:00", DATETIME "2024-02-01 16:00:00", DAY)`,
+			expectedRows: [][]interface{}{{int64(0)}},
+		},
+		{
+			name:         "datetime_diff with day, less than 24 hours and does cross boundary, reverse",
+			query:        `SELECT DATETIME_DIFF(DATETIME "2024-02-01 15:30:00", DATETIME "2024-02-02 02:00:00", DAY)`,
+			expectedRows: [][]interface{}{{int64(-1)}},
 		},
 		{
 			name:         "datetime_diff with week",


### PR DESCRIPTION
This commit updates the `DATE_DIFF` function to fix results when the input times differ by a duration of time that is not evenly divisible by 24 hours, but does not cross a day boundary. The problem occurs because the function unconditionally increments the number of days difference when there is a non-zero remainder when dividing the difference by 24 hours, when it should only increment the difference if that remainder is enough to take the start timestamp to a new day:

https://github.com/goccy/go-zetasqlite/blob/9d65c7df351bc4b9056c6610acffdfbcdfc8c1b9/internal/function_date.go#L152-L157

This commit fixes the problem by truncating the end time to the closest day before calculating the difference and remainder.

Fixes #229