### PR TITLE
fix(rows): properly convert interface values for RECORD fields

### DIFF
--- a/internal/encoder.go
+++ b/internal/encoder.go
@@ -280,9 +280,7 @@ func timestampValueFromLiteral(t time.Time) (TimestampValue, error) {
 	return TimestampValue(t), nil
 }
 
-var (
-	numericLiteralPattern = regexp.MustCompile(`NUMERIC "(.+)"`)
-)
+var numericLiteralPattern = regexp.MustCompile(`NUMERIC "(.+)"`)
 
 func numericValueFromLiteral(lit string) (*NumericValue, error) {
 	matches := numericLiteralPattern.FindAllStringSubmatch(lit, -1)
@@ -305,9 +303,7 @@ func jsonValueFromLiteral(lit string) (JsonValue, error) {
 	return JsonValue(lit), nil
 }
 
-var (
-	intervalLiteralPattern = regexp.MustCompile(`INTERVAL "(.+)"`)
-)
+var intervalLiteralPattern = regexp.MustCompile(`INTERVAL "(.+)"`)
 
 func intervalValueFromLiteral(lit string) (*IntervalValue, error) {
 	matches := intervalLiteralPattern.FindAllStringSubmatch(lit, -1)
@@ -437,9 +433,13 @@ func CastValue(t types.Type, v Value) (Value, error) {
 		if array, ok := v.(*ArrayValue); ok {
 			ret := &StructValue{m: map[string]Value{}}
 			for _, value := range array.values {
-				st, err := value.ToStruct()
+				casted, err := castStruct(t.AsStruct(), value)
 				if err != nil {
 					return nil, err
+				}
+				st, ok := casted.(*StructValue)
+				if !ok {
+					return nil, fmt.Errorf("casting to struct returned non-struct: %T", casted)
 				}
 				ret.keys = append(ret.keys, st.keys...)
 				ret.values = append(ret.values, st.values...)
@@ -449,38 +449,7 @@ func CastValue(t types.Type, v Value) (Value, error) {
 			}
 			return ret, nil
 		}
-		s, err := v.ToStruct()
-		if err != nil {
-			return nil, err
-		}
-		typ := t.AsStruct()
-		anonymousStruct := true
-		for _, key := range s.keys {
-			if key != "" {
-				anonymousStruct = false
-			}
-		}
-		if anonymousStruct {
-			return s, nil
-		}
-		ret := &StructValue{m: s.m}
-		for i := 0; i < typ.NumFields(); i++ {
-			key := typ.Field(i).Name()
-			value, exists := s.m[key]
-			if !exists {
-				ret.keys = append(ret.keys, key)
-				ret.values = append(ret.values, nil)
-				continue
-			}
-			casted, err := CastValue(typ.Field(i).Type(), value)
-			if err != nil {
-				return nil, err
-			}
-			ret.keys = append(ret.keys, key)
-			ret.values = append(ret.values, casted)
-			ret.m[key] = casted
-		}
-		return ret, nil
+		return castStruct(t, v)
 	case types.NUMERIC:
 		r, err := v.ToRat()
 		if err != nil {
@@ -503,6 +472,41 @@ func CastValue(t types.Type, v Value) (Value, error) {
 		return v, nil
 	}
 	return nil, fmt.Errorf("unsupported cast %s value", t.Kind())
+}
+
+func castStruct(t types.Type, v Value) (Value, error) {
+	s, err := v.ToStruct()
+	if err != nil {
+		return nil, err
+	}
+	typ := t.AsStruct()
+	anonymousStruct := true
+	for _, key := range s.keys {
+		if key != "" {
+			anonymousStruct = false
+		}
+	}
+	if anonymousStruct {
+		return s, nil
+	}
+	ret := &StructValue{m: s.m}
+	for i := 0; i < typ.NumFields(); i++ {
+		key := typ.Field(i).Name()
+		value, exists := s.m[key]
+		if !exists {
+			ret.keys = append(ret.keys, key)
+			ret.values = append(ret.values, nil)
+			continue
+		}
+		casted, err := CastValue(typ.Field(i).Type(), value)
+		if err != nil {
+			return nil, err
+		}
+		ret.keys = append(ret.keys, key)
+		ret.values = append(ret.values, casted)
+		ret.m[key] = casted
+	}
+	return ret, nil
 }
 
 func ValueFromGoValue(v interface{}) (Value, error) {

--- a/internal/encoder.go
+++ b/internal/encoder.go
@@ -441,15 +441,21 @@ func CastValue(t types.Type, v Value) (Value, error) {
 				if !ok {
 					return nil, fmt.Errorf("casting to struct returned non-struct: %T", casted)
 				}
-				ret.keys = append(ret.keys, st.keys...)
-				ret.values = append(ret.values, st.values...)
 				for i, k := range st.keys {
-					ret.m[k] = st.values[i]
+					prev, ok := ret.m[k]
+					if !ok || prev == nil {
+						ret.m[k] = st.values[i]
+					}
 				}
+			}
+			for k, v := range ret.m {
+				ret.keys = append(ret.keys, k)
+				ret.values = append(ret.values, v)
 			}
 			return ret, nil
 		}
 		return castStruct(t, v)
+
 	case types.NUMERIC:
 		r, err := v.ToRat()
 		if err != nil {

--- a/internal/rows.go
+++ b/internal/rows.go
@@ -215,7 +215,7 @@ func (r *Rows) assignInterfaceValue(src Value, dst reflect.Value, typ *Type) err
 		if err != nil {
 			return err
 		}
-		dst.Set(reflect.ValueOf(i64))
+		dst.Set(reflect.ValueOf(i64).Convert(dst.Type()))
 	case types.BOOL:
 		b, err := src.ToBool()
 		if err != nil {
@@ -296,7 +296,26 @@ func (r *Rows) assignInterfaceValue(src Value, dst reflect.Value, typ *Type) err
 		if err != nil {
 			return err
 		}
-		dst.Set(reflect.ValueOf(s.Interface()))
+		fields := s.Interface().([]map[string]interface{})
+
+		// Assign interface values for all child fields
+		for i := range s.keys {
+			innerKey := s.keys[i]
+			innerValue := s.values[i]
+			innerType := typ.FieldTypes[i].Type
+			if innerValue == nil {
+				continue
+			}
+
+			refT := reflect.TypeOf(innerValue.Interface())
+			refV := reflect.New(refT).Elem()
+			if err := r.assignInterfaceValue(innerValue, refV, innerType); err != nil {
+				return err
+			}
+			fields[i][innerKey] = refV.Interface()
+
+		}
+		dst.Set(reflect.ValueOf(fields))
 	case types.ARRAY:
 		array, err := src.ToArray()
 		if err != nil {

--- a/internal/rows.go
+++ b/internal/rows.go
@@ -313,7 +313,6 @@ func (r *Rows) assignInterfaceValue(src Value, dst reflect.Value, typ *Type) err
 				return err
 			}
 			fields[i][innerKey] = refV.Interface()
-
 		}
 		dst.Set(reflect.ValueOf(fields))
 	case types.ARRAY:

--- a/query_test.go
+++ b/query_test.go
@@ -557,6 +557,15 @@ SELECT t.customer.address.country FROM orders AS t`,
 			expectedRows: [][]interface{}{{createTimestampFormatFromTime(now.UTC()), false}},
 		},
 		{
+			name:  "struct with timestamp",
+			query: `SELECT STRUCT(CURRENT_TIMESTAMP() AS ts)`,
+			expectedRows: [][]interface{}{{
+				[]map[string]interface{}{{
+					"ts": createTimestampFormatFromTime(now.UTC()),
+				}},
+			}},
+		},
+		{
 			name: "array index access operator",
 			query: `
 WITH Items AS (SELECT ["coffee", "tea", "milk"] AS item_array)
@@ -2412,7 +2421,8 @@ SELECT ARRAY (
 					int64(1),
 				},
 			},
-		}, {
+		},
+		{
 			name:  "array_concat function",
 			query: `SELECT ARRAY_CONCAT([1, 2], [3, 4], [5, 6]) as count_to_six`,
 			expectedRows: [][]interface{}{
@@ -3884,7 +3894,8 @@ WITH letters AS (
 				{[]interface{}{"b", "c", "d"}},
 				{[]interface{}{}},
 			},
-		}, {
+		},
+		{
 			name:         "split null delimiter",
 			query:        `SELECT SPLIT('abc', NULL), SPLIT(b'\xab\xcd\xef\xaa\xbb', NULL)`,
 			expectedRows: [][]interface{}{{[]interface{}{}, []interface{}{}}},
@@ -4016,7 +4027,6 @@ WITH example AS (
 			expectedRows: [][]interface{}{{"2023-02-28"}},
 		},
 		{
-
 			name:         "date_add quarter",
 			query:        `SELECT DATE_ADD('2023-01-01', INTERVAL 1 QUARTER), DATE_ADD('2023-11-30', INTERVAL 1 QUARTER)`,
 			expectedRows: [][]interface{}{{"2023-04-01", "2024-02-29"}},
@@ -4872,7 +4882,8 @@ SELECT date, EXTRACT(ISOYEAR FROM date), EXTRACT(YEAR FROM date), EXTRACT(MONTH 
 			query:        `SELECT PARSE_TIMESTAMP("%k", " 9");`,
 			expectedRows: [][]interface{}{{createTimestampFormatFromString("1970-01-01 09:00:00+00")}},
 		},
-		{name: "parse_timestamp with %D",
+		{
+			name:         "parse_timestamp with %D",
 			query:        `SELECT PARSE_TIMESTAMP("%D", "02/02/99");`,
 			expectedRows: [][]interface{}{{createTimestampFormatFromString("1999-02-02 00:00:00+00")}},
 		},

--- a/query_test.go
+++ b/query_test.go
@@ -558,11 +558,12 @@ SELECT t.customer.address.country FROM orders AS t`,
 		},
 		{
 			name:  "struct with timestamp",
-			query: `SELECT STRUCT(CURRENT_TIMESTAMP() AS ts)`,
+			query: `SELECT STRUCT(CURRENT_TIMESTAMP() AS ts, "123" AS id)`,
 			expectedRows: [][]interface{}{{
-				[]map[string]interface{}{{
-					"ts": createTimestampFormatFromTime(now.UTC()),
-				}},
+				[]map[string]interface{}{
+					{"ts": createTimestampFormatFromTime(now.UTC())},
+					{"id": "123"},
+				},
 			}},
 		},
 		{


### PR DESCRIPTION
# Summary

Both `zetasqlite` and `bigquery-emulator` treat record columns inconsistently in some places, and it's bitten us for the last week. Finally narrowed it down to these code paths:

- When casting `RECORD` fields from their Go types -> storage
- When casting `RECORD` fields from storage -> Go types

This changes both to convert nested fields recursively for struct types. I personally hit it the most in records that have timestamps — they weren't getting converted to unix micros, so were failing a lot of logic on the `bigquery-emulator` side for decoding.

Relates to goccy/bigquery-emulator#416

# Test Plan

There are several broken tests on `main`, but this change doesn't contribute extra failures. I've included a test for this specific scenario to prevent regression.

```
> go test ./... -run=TestQuery/struct_with_timestamp
ok      github.com/goccy/go-zetasqlite  0.899s
ok      github.com/goccy/go-zetasqlite/internal (cached) [no tests to run]
```