### PR TITLE
fix: DATE_DIFF DAY counts day boundaries instead of rounding

### DIFF
--- a/internal/function_date.go
+++ b/internal/function_date.go
@@ -144,17 +144,14 @@ func DATE_DIFF(a, b time.Time, part string) (Value, error) {
 		return IntValue(result), nil
 	}
 
-	diff := a.Sub(b)
 
 	switch part {
 	case "DAY":
-		diffDay := diff / (24 * time.Hour)
-		mod := diff % (24 * time.Hour)
-		if mod > 0 {
-			diffDay++
-		} else if mod < 0 {
-			diffDay--
-		}
+		// Count the number of day boundaries (midnights) between b and a.
+		// Truncate both to midnight and compute the difference in days.
+		aDay := time.Date(a.Year(), a.Month(), a.Day(), 0, 0, 0, 0, a.Location())
+		bDay := time.Date(b.Year(), b.Month(), b.Day(), 0, 0, 0, 0, b.Location())
+		diffDay := aDay.Sub(bDay) / (24 * time.Hour)
 		return IntValue(diffDay), nil
 	case "ISOWEEK":
 		return IntValue((a.Year()-b.Year())*48 + weekA - weekB), nil


### PR DESCRIPTION
Fixes #229

## Problem

`DATE_DIFF` with `DAY` part uses duration division with rounding, which gives incorrect results for same-day timestamps:

```sql
SELECT DATETIME_DIFF(DATETIME "2024-02-01 16:00:00", DATETIME "2024-02-01 15:30:00", DAY) as diff_day
-- Expected: 0
-- Got: 1
```

The old code divides `a.Sub(b)` by 24h and rounds up any remainder, treating 30 minutes as a full day.

## Fix

BigQuery's `DATE_DIFF`/`DATETIME_DIFF` counts the number of **day boundaries** (midnights) crossed. Truncate both timestamps to midnight and compute the difference:

```go
aDay := time.Date(a.Year(), a.Month(), a.Day(), 0, 0, 0, 0, a.Location())
bDay := time.Date(b.Year(), b.Month(), b.Day(), 0, 0, 0, 0, b.Location())
diffDay := aDay.Sub(bDay) / (24 * time.Hour)
```