### PR TITLE
Support PARTITION BY and CLUSTER BY in CREATE TABLE

### DIFF
--- a/exec_test.go
+++ b/exec_test.go
@@ -339,6 +339,134 @@ func TestWildcardTable(t *testing.T) {
 	})
 }
 
+func TestCreateTableWithPartitionBy(t *testing.T) {
+	ctx := context.Background()
+	db, err := sql.Open("zetasqlite", ":memory:")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer db.Close()
+
+	t.Run("partition by date", func(t *testing.T) {
+		if _, err := db.ExecContext(ctx, `
+			CREATE TABLE partition_test1 (
+				id INT64,
+				name STRING,
+				created_at TIMESTAMP
+			) PARTITION BY DATE(created_at)
+		`); err != nil {
+			t.Fatal(err)
+		}
+		// table should be queryable
+		if _, err := db.ExecContext(ctx, `INSERT INTO partition_test1 (id, name, created_at) VALUES (1, 'test', '2024-01-01 00:00:00+00')`); err != nil {
+			t.Fatal(err)
+		}
+		rows, err := db.QueryContext(ctx, "SELECT id, name FROM partition_test1")
+		if err != nil {
+			t.Fatal(err)
+		}
+		defer rows.Close()
+		rows.Next()
+		var id int64
+		var name string
+		if err := rows.Scan(&id, &name); err != nil {
+			t.Fatal(err)
+		}
+		if id != 1 || name != "test" {
+			t.Fatalf("unexpected row: id=%d, name=%s", id, name)
+		}
+		if err := rows.Err(); err != nil {
+			t.Fatal(err)
+		}
+	})
+
+	t.Run("cluster by", func(t *testing.T) {
+		if _, err := db.ExecContext(ctx, `
+			CREATE TABLE cluster_test1 (
+				id INT64,
+				name STRING,
+				category STRING
+			) CLUSTER BY name, category
+		`); err != nil {
+			t.Fatal(err)
+		}
+		if _, err := db.ExecContext(ctx, `INSERT INTO cluster_test1 (id, name, category) VALUES (1, 'a', 'b')`); err != nil {
+			t.Fatal(err)
+		}
+		rows, err := db.QueryContext(ctx, "SELECT id FROM cluster_test1")
+		if err != nil {
+			t.Fatal(err)
+		}
+		defer rows.Close()
+		rows.Next()
+		var id int64
+		if err := rows.Scan(&id); err != nil {
+			t.Fatal(err)
+		}
+		if id != 1 {
+			t.Fatalf("unexpected id: %d", id)
+		}
+		if err := rows.Err(); err != nil {
+			t.Fatal(err)
+		}
+	})
+
+	t.Run("partition by and cluster by", func(t *testing.T) {
+		if _, err := db.ExecContext(ctx, `
+			CREATE TABLE partition_cluster_test1 (
+				run_id STRING NOT NULL,
+				pr_number INT64,
+				pr_author STRING,
+				created_at TIMESTAMP
+			)
+			PARTITION BY DATE(created_at)
+			CLUSTER BY run_id, pr_number, pr_author
+		`); err != nil {
+			t.Fatal(err)
+		}
+		if _, err := db.ExecContext(ctx, `INSERT INTO partition_cluster_test1 (run_id, pr_number, pr_author, created_at) VALUES ('run1', 123, 'marcus', '2024-01-01 00:00:00+00')`); err != nil {
+			t.Fatal(err)
+		}
+		rows, err := db.QueryContext(ctx, "SELECT run_id, pr_number, pr_author FROM partition_cluster_test1")
+		if err != nil {
+			t.Fatal(err)
+		}
+		defer rows.Close()
+		rows.Next()
+		var runID, prAuthor string
+		var prNumber int64
+		if err := rows.Scan(&runID, &prNumber, &prAuthor); err != nil {
+			t.Fatal(err)
+		}
+		if runID != "run1" || prNumber != 123 || prAuthor != "marcus" {
+			t.Fatalf("unexpected row: run_id=%s, pr_number=%d, pr_author=%s", runID, prNumber, prAuthor)
+		}
+		if err := rows.Err(); err != nil {
+			t.Fatal(err)
+		}
+	})
+
+	t.Run("create if not exists with partition", func(t *testing.T) {
+		if _, err := db.ExecContext(ctx, `
+			CREATE TABLE IF NOT EXISTS partition_ifne_test (
+				id INT64,
+				ts TIMESTAMP
+			) PARTITION BY DATE(ts)
+		`); err != nil {
+			t.Fatal(err)
+		}
+		// creating again should not error
+		if _, err := db.ExecContext(ctx, `
+			CREATE TABLE IF NOT EXISTS partition_ifne_test (
+				id INT64,
+				ts TIMESTAMP
+			) PARTITION BY DATE(ts)
+		`); err != nil {
+			t.Fatal(err)
+		}
+	})
+}
+
 func TestTemplatedArgFunc(t *testing.T) {
 	ctx := context.Background()
 	db, err := sql.Open("zetasqlite", ":memory:")

--- a/internal/analyzer.go
+++ b/internal/analyzer.go
@@ -76,6 +76,8 @@ func newAnalyzerOptions() (*zetasql.AnalyzerOptions, error) {
 		zetasql.FeatureV13Pivot,
 		zetasql.FeatureV13Unpivot,
 		zetasql.FeatureCreateTableAsSelectColumnList,
+		zetasql.FeatureCreateTablePartitionBy,
+		zetasql.FeatureCreateTableClusterBy,
 	})
 	langOpt.SetSupportedStatementKinds([]ast.Kind{
 		ast.BeginStmt,

--- a/internal/spec.go
+++ b/internal/spec.go
@@ -103,15 +103,17 @@ func (s *FunctionSpec) CallSQL(ctx context.Context, callNode *ast.BaseFunctionCa
 }
 
 type TableSpec struct {
-	IsTemp     bool           `json:"isTemp"`
-	IsView     bool           `json:"isView"`
-	NamePath   []string       `json:"namePath"`
-	Columns    []*ColumnSpec  `json:"columns"`
-	PrimaryKey []string       `json:"primaryKey"`
-	CreateMode ast.CreateMode `json:"createMode"`
-	Query      string         `json:"query"`
-	UpdatedAt  time.Time      `json:"updatedAt"`
-	CreatedAt  time.Time      `json:"createdAt"`
+	IsTemp      bool           `json:"isTemp"`
+	IsView      bool           `json:"isView"`
+	NamePath    []string       `json:"namePath"`
+	Columns     []*ColumnSpec  `json:"columns"`
+	PrimaryKey  []string       `json:"primaryKey"`
+	CreateMode  ast.CreateMode `json:"createMode"`
+	Query       string         `json:"query"`
+	PartitionBy []string       `json:"partitionBy,omitempty"`
+	ClusterBy   []string       `json:"clusterBy,omitempty"`
+	UpdatedAt   time.Time      `json:"updatedAt"`
+	CreatedAt   time.Time      `json:"createdAt"`
 }
 
 func (s *TableSpec) Column(name string) *ColumnSpec {
@@ -516,14 +518,45 @@ func newPrimaryKey(key *ast.PrimaryKeyNode) []string {
 func newTableSpec(namePath *NamePath, stmt *ast.CreateTableStmtNode) *TableSpec {
 	now := time.Now()
 	return &TableSpec{
-		IsTemp:     stmt.CreateScope() == ast.CreateScopeTemp,
-		NamePath:   namePath.mergePath(stmt.NamePath()),
-		Columns:    newColumnsFromDef(stmt.ColumnDefinitionList()),
-		PrimaryKey: newPrimaryKey(stmt.PrimaryKey()),
-		CreateMode: stmt.CreateMode(),
-		UpdatedAt:  now,
-		CreatedAt:  now,
+		IsTemp:      stmt.CreateScope() == ast.CreateScopeTemp,
+		NamePath:    namePath.mergePath(stmt.NamePath()),
+		Columns:     newColumnsFromDef(stmt.ColumnDefinitionList()),
+		PrimaryKey:  newPrimaryKey(stmt.PrimaryKey()),
+		CreateMode:  stmt.CreateMode(),
+		PartitionBy: exprsToStrings(stmt.PartitionByList()),
+		ClusterBy:   exprsToStrings(stmt.ClusterByList()),
+		UpdatedAt:   now,
+		CreatedAt:   now,
 	}
+}
+
+func exprsToStrings(exprs []ast.ExprNode) []string {
+	if len(exprs) == 0 {
+		return nil
+	}
+	out := make([]string, len(exprs))
+	for i, expr := range exprs {
+		out[i] = extractColumnName(expr)
+	}
+	return out
+}
+
+// extractColumnName extracts the column name from a resolved AST expression.
+// For ColumnRef nodes, it returns the column name directly.
+// For FunctionCall nodes (e.g. DATE(ts)), it walks the arguments to find the column.
+// Falls back to DebugString if no column reference is found.
+func extractColumnName(expr ast.ExprNode) string {
+	switch expr.Kind() {
+	case ast.ColumnRef:
+		return expr.(*ast.ColumnRefNode).Column().Name()
+	case ast.FunctionCall:
+		for _, arg := range expr.(*ast.FunctionCallNode).ArgumentList() {
+			if name := extractColumnName(arg); name != "" {
+				return name
+			}
+		}
+	}
+	return expr.DebugString()
 }
 
 func newTableAsViewSpec(namePath *NamePath, query string, stmt *ast.CreateViewStmtNode) *TableSpec {
@@ -563,14 +596,16 @@ func newTableAsSelectSpec(namePath *NamePath, query string, stmt *ast.CreateTabl
 	}
 	now := time.Now()
 	return &TableSpec{
-		IsTemp:     stmt.CreateScope() == ast.CreateScopeTemp,
-		NamePath:   namePath.mergePath(stmt.NamePath()),
-		Columns:    newColumnsFromDef(stmt.ColumnDefinitionList()),
-		PrimaryKey: newPrimaryKey(stmt.PrimaryKey()),
-		CreateMode: stmt.CreateMode(),
-		Query:      fmt.Sprintf("SELECT %s FROM (%s)", strings.Join(outputColumns, ","), query),
-		UpdatedAt:  now,
-		CreatedAt:  now,
+		IsTemp:      stmt.CreateScope() == ast.CreateScopeTemp,
+		NamePath:    namePath.mergePath(stmt.NamePath()),
+		Columns:     newColumnsFromDef(stmt.ColumnDefinitionList()),
+		PrimaryKey:  newPrimaryKey(stmt.PrimaryKey()),
+		CreateMode:  stmt.CreateMode(),
+		Query:       fmt.Sprintf("SELECT %s FROM (%s)", strings.Join(outputColumns, ","), query),
+		PartitionBy: exprsToStrings(stmt.PartitionByList()),
+		ClusterBy:   exprsToStrings(stmt.ClusterByList()),
+		UpdatedAt:   now,
+		CreatedAt:   now,
 	}
 }
 


### PR DESCRIPTION
## Summary

CREATE TABLE statements that include PARTITION BY or CLUSTER BY clauses currently fail with `CREATE TABLE with PARTITION BY is unsupported`. This happens because the ZetaSQL analyzer does not have the corresponding language features enabled.

This PR enables `FeatureCreateTablePartitionBy` and `FeatureCreateTableClusterBy` in the analyzer options, adds `PartitionBy` and `ClusterBy` fields to `TableSpec`, and extracts the column names from the resolved AST so that consumers like bigquery-emulator can use them.

No actual data partitioning is performed in SQLite since it does not support these clauses natively. The generated SQLite DDL stays the same as before. This is purely a metadata extension.

## What changed

**internal/analyzer.go**: Added `FeatureCreateTablePartitionBy` and `FeatureCreateTableClusterBy` to the enabled language features list.

**internal/spec.go**: Added `PartitionBy` and `ClusterBy` fields to `TableSpec`. Both `newTableSpec` and `newTableAsSelectSpec` now extract partition and cluster column names from the AST. A helper `extractColumnName` walks function call expressions (like `DATE(ts)`) to resolve the underlying column reference.

**exec_test.go**: Added `TestCreateTableWithPartitionBy` covering four cases: partition by date, cluster by, both combined, and CREATE IF NOT EXISTS with partition. Each test also verifies that the table is fully queryable after creation.

## Motivation

This is the prerequisite for fixing goccy/bigquery-emulator#152 where the emulator crashes on any CREATE TABLE that includes PARTITION BY.